### PR TITLE
Add basic theme switcher

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,6 +1,9 @@
 import { SUPABASE } from '../helpers/supabaseClient';
 import { Link } from 'react-router-dom';
 import { User, Session } from '../types';
+import { useState, useEffect } from 'react';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+import LightModeIcon from '@mui/icons-material/LightMode';
 
 interface NavProps { user: User | null, session: Session | null }
 
@@ -11,6 +14,28 @@ interface NavProps { user: User | null, session: Session | null }
  */
 
 export default function Navigation(props: NavProps): JSX.Element {
+
+	const [themeIcon, setThemeIcon] = useState(<DarkModeIcon />);
+	useEffect(() => {
+		if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+			document.documentElement.classList.add('dark');
+			setThemeIcon(<DarkModeIcon />);
+		} else {
+			document.documentElement.classList.remove('dark');
+			setThemeIcon(<LightModeIcon />);
+		}
+	}, []);
+
+	const themeSwitcher = () => {
+		if (localStorage.theme === 'dark' || (!('theme' in localStorage) && document.documentElement.classList.contains('dark'))) {
+			localStorage.theme = 'light';
+			setThemeIcon(<LightModeIcon />);
+		} else {
+			localStorage.theme = 'dark';
+			setThemeIcon(<DarkModeIcon />);
+		}
+		document.documentElement.classList.toggle('dark');
+	};
 
 	console.log(props);
 	const logoutHandler = async () => {
@@ -32,6 +57,10 @@ export default function Navigation(props: NavProps): JSX.Element {
 					<Link to="/auth/login" style={{ padding: '0 5px' }}>Login</Link>
 				</>
 			)}
+			<button
+				onClick={themeSwitcher}>
+				{themeIcon}
+			</button>
 		</>
 	);
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,6 +4,7 @@ module.exports = {
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
+  darkMode: 'class',
   theme: {
     extend: {},
   },


### PR DESCRIPTION
Created basic theme switcher that adds the `dark` class to the root element depending on the users device system default setting, or upon manual button press where it is then saved to `localStorage`.

Closes #97