### PR TITLE
Profile Context

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,7 +7,25 @@
 
 echo "--- Building App ---"
 npm run build
+if [[ "$?" == 0 ]]; then
+    echo "\t\033[32mBuild Passed\033[0m"
+else
+    echo "\t\033[41mBuild Failed\033[0m"
+    exit 1
+fi
 echo "--- Running ES-Lint ---"
 npm run lint
+if [[ "$?" == 0 ]]; then
+    echo "\t\033[32mESLint Passed\033[0m"
+else
+    echo "\t\033[41mESLint Failed\033[0m"
+    exit 1
+fi
 echo "--- Running Unit Tests ---"
 npm run test
+if [[ "$?" == 0 ]]; then
+    echo "\t\033[32mUnit Tests Passed\033[0m"
+else
+    echo "\t\033[41mUnit Tests Failed\033[0m"
+    exit 1
+fi

--- a/src/AppWrapper.tsx
+++ b/src/AppWrapper.tsx
@@ -1,9 +1,10 @@
 import { Outlet } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { SUPABASE } from './helpers/supabaseClient';
-import type { User, Session } from './types';
+import type { Session, Profile } from './types';
 import './App.css';
 import Navigation from './components/Navigation';
+import { getProfileById } from './supabase/profiles';
 
 /**
  * The main app function, wrapping all other screens and components
@@ -13,30 +14,75 @@ import Navigation from './components/Navigation';
  */
 export default function AppWrapper(): JSX.Element {
 	const [session, setSession] = useState<Session | null>(null);
-	const [user, setUser] = useState<User | null>(null);
+	const [profile, setProfile] = useState<Profile | null>(null);
 
 	/**
-	 * @TODO Add error handling. Move this logic to util file? 
-	 * @TODO Figure out how have onAuthStateChange listen always
+     * When the session changed, this function will
+     * update the profile context accordingly
+     * 
+     * @param session | logged in user's details or null
+     */
+	const profileSetter = async (session: Session) => {
+		if (session) {
+			const data = await getProfileById(session.user.id);
+			setProfile(data);
+		}
+	};
+    
+	/**
+     * @TODO Move auth functions to util file?
 	 */
 	useEffect(() => {
-		SUPABASE.auth.getSession().then(({ data: { session } }) => {
+		SUPABASE.auth.getSession().then(({ data: { session }, error }) => {
+			if (error) {
+				if (import.meta.env.DEV) console.error(error);
+				return;
+			}
 			setSession(session as Session);
-			setUser(session?.user as User);
+			profileSetter(session as Session);
 		});
 
-		SUPABASE.auth.onAuthStateChange((_event, session) => {
-			setSession(session as Session);
-			setUser(session?.user as User);
+		const { data } = SUPABASE.auth.onAuthStateChange((_event, session) => {
+			switch (_event) {
+			case 'SIGNED_IN':
+				setSession(session as Session);
+				profileSetter(session as Session);
+				break;
+			case 'SIGNED_OUT':
+				setSession(null);
+				setProfile(null);
+				break;
+			case 'TOKEN_REFRESHED':
+				setSession(session as Session);
+				break;
+			case 'USER_UPDATED':
+				setSession(session as Session);
+				profileSetter(session as Session);
+				break;
+			case 'USER_DELETED':
+				setSession(null);
+				setProfile(null);
+				break;
+			case 'PASSWORD_RECOVERY':
+				setSession(session as Session);
+				break;
+			case 'MFA_CHALLENGE_VERIFIED':
+				setSession(session as Session);
+				break;
+			}
 		});
+
+		return () => {
+			data.subscription.unsubscribe();
+		};
 	}, []);
-
+    
 	return (
 		<div className="App">
-			<Navigation user={user} session={session} />
+			<Navigation session={session} />
 			<h1>Streamability</h1>
 			<div>
-				<Outlet context={{ session, user, setUser }} />
+				<Outlet context={{ session, profile, setProfile }} />
 			</div>
 		</div>
 	);

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,21 +1,21 @@
 import { SUPABASE } from '../helpers/supabaseClient';
 import { Link } from 'react-router-dom';
-import { User, Session } from '../types';
+import { Session } from '../types';
 import { useState, useEffect } from 'react';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import LightModeIcon from '@mui/icons-material/LightMode';
 
-interface NavProps { user: User | null, session: Session | null }
+interface NavProps { session: Session | null }
 
 /**
- * This component will be rendered in AppWapper.tsx - on every page.
+ * This component will be rendered in AppWrapper.tsx - on every page.
  * Navigation elements are placeholder for the time being for development purposes.
  * @returns {JSX.Element} | Navigation
  */
 
 export default function Navigation(props: NavProps): JSX.Element {
-
 	const [themeIcon, setThemeIcon] = useState(<DarkModeIcon />);
+
 	useEffect(() => {
 		if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
 			document.documentElement.classList.add('dark');
@@ -37,7 +37,6 @@ export default function Navigation(props: NavProps): JSX.Element {
 		document.documentElement.classList.toggle('dark');
 	};
 
-	console.log(props);
 	const logoutHandler = async () => {
 		// TODO: Error handling if any
 		await SUPABASE.auth.signOut();
@@ -46,10 +45,10 @@ export default function Navigation(props: NavProps): JSX.Element {
 	// TODO: Remove inline styling upon CSS framework integration
 		<>
 			<Link to="/" style={{ padding: '0 5px' }}>Home</Link>
-			{props.session && props.user ? (
+			{props.session ? (
 				<>
 					<Link to="/dashboard" style={{ padding: '0 5px' }}>Dashboard</Link>
-					<span onClick={logoutHandler} style={{ padding: '0 5px' }}>Logout</span>
+					<a onClick={logoutHandler} style={{ padding: '0 5px' }}>Logout</a>
 				</>
 			) : (
 				<>

--- a/src/components/ShowCard.tsx
+++ b/src/components/ShowCard.tsx
@@ -1,4 +1,4 @@
-import { useUserContext } from '../hooks';
+import { useProfileContext } from '../hooks';
 import { addToProfileWatchQueue, removeFromProfileWatchQueue } from '../supabase/profiles';
 import { MovieDetailsData } from '../types/tmdb';
 
@@ -13,7 +13,7 @@ interface MovieCardProps { details: MovieDetailsData | null }
  * @returns {JSX.Element} | Single show card
  */
 export default function ShowCard(props: MovieCardProps): JSX.Element {
-	const { user } = useUserContext();
+	const { profile, setProfile } = useProfileContext();
 
 	const ratingHandler = (arr: MovieDetailsData): JSX.Element | null => {
 		for (let i = 0; i < arr.release_dates.results.length; i++) {
@@ -33,14 +33,12 @@ export default function ShowCard(props: MovieCardProps): JSX.Element {
      */
 	const queueHandler = async (isPush: boolean, show_id: number | undefined) => {
 		if (show_id) {
-			if (isPush && user) {
-				const data = await addToProfileWatchQueue(user.id, show_id);
-				// TODO: #141 Create a profile context and update it here
-				console.log(data);
-			} else if (user) {
-				const data = await removeFromProfileWatchQueue(user.id, show_id);
-				// TODO: #141 Create a profile context and update it here
-				console.log(data);
+			if (isPush && profile) {
+				const data = await addToProfileWatchQueue(profile.id, show_id);
+				setProfile(data);
+			} else if (profile) {
+				const data = await removeFromProfileWatchQueue(profile.id, show_id);
+				setProfile(data);
 			}
 		}
 	};

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
 import { SUPABASE } from '../../helpers/supabaseClient';
-import { User } from '../../types';
-import { useUserContext } from '../../hooks';
 
 /**
  * @returns {JSX.Element}
@@ -10,7 +8,6 @@ export default function LoginForm(): JSX.Element {
 	const [email, setEmail] = useState('');
 	const [password, setPassword] = useState('');
 	const [errorMessage, setErrorMessage] = useState('');
-	const { setUser } = useUserContext();
 
 	/**
      * Function to authenticate and perform Supabase login
@@ -30,7 +27,7 @@ export default function LoginForm(): JSX.Element {
 		}
 
 		// Perform Supabase login request
-		const { data, error } = await SUPABASE.auth.signInWithPassword({
+		const { error } = await SUPABASE.auth.signInWithPassword({
 			email: email,
 			password: password,
 		});
@@ -38,11 +35,10 @@ export default function LoginForm(): JSX.Element {
 		if (error) {
 			// We could try to get the AuthApiError type and use 'cause' instead
 			setErrorMessage(error.message);
-			// TODO: Remove in production env
-			console.error(error);
+			if (import.meta.env.DEV) console.error(error);
 		} else {
 			setErrorMessage('');
-			setUser(data.user as User);
+			// onAuthStateChange function will be triggered
 		}
 
 		return;

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 import ErrorMessage from '../ErrorMessage';
 import { SUPABASE } from '../../helpers/supabaseClient';
-import { useUserContext } from '../../hooks';
-import { User } from '../../types';
 
 /**
  * Screen to handle Supabase sign up
@@ -15,7 +13,6 @@ export default function SignUpForm(): JSX.Element {
 	const [password, setPassword] = useState('');
 	const [confirmPassword, setConfirmPassword] = useState('');
 	const [errorMessage, setErrorMessage] = useState('');
-	const { setUser } = useUserContext();
 
 	/**
      * Function to authenticate and perform Supabase sign up
@@ -41,7 +38,7 @@ export default function SignUpForm(): JSX.Element {
 		}
 
 		// Perform Supabase sign up POST request
-		const { data, error } = await SUPABASE.auth.signUp({
+		const { error } = await SUPABASE.auth.signUp({
 			email: email,
 			password: password,
 			options: {
@@ -53,14 +50,12 @@ export default function SignUpForm(): JSX.Element {
 
 		if (error) {
 			setErrorMessage(error.message);
-			// TODO: Remove in production env
-			console.error(error);
+			if (import.meta.env.DEV) console.error(error);
 		} else {
 			setErrorMessage('');
+			// onAuthStateChange function will be triggered
 			// User has not logged in yet but we still get some information back
 			// Check if 'confirmed_at' exists on user to see if they validated their email
-			// Create profile in DB for accessible information
-			setUser(data.user as User);
 		}
 
 		return;

--- a/src/helpers/getMovieUtils.ts
+++ b/src/helpers/getMovieUtils.ts
@@ -1,17 +1,19 @@
 import { MovieData, MovieDetailsData } from '../types/tmdb';
+
 /**
  * This function is ran after the user enters a name of a movie.
  * @returns {Promise<MovieData>} | List of movies by searched query.
  */
-const getMoviesByName = async (name: string) => {
+const getMoviesByName = async (name: string): Promise<MovieData> => {
 	const response = await fetch(`https://api.themoviedb.org/3/search/movie?api_key=${import.meta.env.VITE_MOVIEDB_KEY}&language=en-US&query=${name}&page=1&include_adult=false`);
 	return response.json() as Promise<MovieData>;
 };
+
 /**
  * This function is ran for specific <ShowCard /> data with a movieID. 
  * @returns {Promise<MovieDetailsData>} | Specific data for a movie that is not originally supplied by getMoviesByName.
  */
-const getMovieDetails = async (id: number) => {
+const getMovieDetails = async (id: number): Promise<MovieDetailsData> => {
 	const response = await fetch(`https://api.themoviedb.org/3/movie/${id}?api_key=${import.meta.env.VITE_MOVIEDB_KEY}&append_to_response=images,release_dates`);
 	return response.json() as Promise<MovieDetailsData>;
 };

--- a/src/hooks/context.ts
+++ b/src/hooks/context.ts
@@ -1,17 +1,17 @@
 import { useOutletContext } from 'react-router-dom';
-import type { User, Session } from '../types';
+import type { Profile, Session } from '../types';
 
-// Supabase info about the currently logged in user
-// Setter to update the user info
-type UserContextType = { 
-    user: User | null,
-    setUser: React.Dispatch<React.SetStateAction<User | null>>
+// Supabase info about the currently logged in Profile
+// Setter to update the profile info
+type ProfileContextType = { 
+    profile: Profile | null,
+    setProfile: React.Dispatch<React.SetStateAction<Profile | null>>
 }
 /**
- * @returns {UserContextType}
+ * @returns {ProfileContextType}
  */
-export function useUserContext(): UserContextType {
-	return useOutletContext<UserContextType>();
+export function useProfileContext(): ProfileContextType {
+	return useOutletContext<ProfileContextType>();
 }
 
 // Supabase info about the currently logged in user's session

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,6 @@
-import { useUserContext, useSessionContext } from './context';
+import { useProfileContext, useSessionContext } from './context';
 
 export {
-	useUserContext,
+	useProfileContext,
 	useSessionContext,
 };

--- a/src/screens/AuthScreen.tsx
+++ b/src/screens/AuthScreen.tsx
@@ -1,19 +1,19 @@
 import { Outlet } from 'react-router-dom';
-import { useSessionContext, useUserContext } from '../hooks';
+import { useSessionContext } from '../hooks';
 
 /**
  * Wrapper for all authentication components
+ * LoginForm, SignupForm
  * 
  * @returns {JSX.Element}
  */
 export default function AuthScreen(): JSX.Element {
 	const { session } = useSessionContext();
-	const { user, setUser } = useUserContext();
 
 	return (
 		<>
 			<h1>Auth Screen</h1>
-			<Outlet context={{session, user, setUser}} />
+			<Outlet context={{ session }} />
 		</>
 	);
 }

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -1,40 +1,36 @@
 import { useEffect, useState } from 'react';
 import { SUPABASE } from '../helpers/supabaseClient';
-import { useSessionContext, useUserContext } from '../hooks';
-import { deleteProfileById, getProfileById, updateProfileUsername, getProfileWatchQueue } from '../supabase/profiles';
-import { Profile } from '../types/supabase';
+import { useSessionContext, useProfileContext } from '../hooks';
+import { deleteProfileById, updateProfileUsername, getProfileWatchQueue } from '../supabase/profiles';
 
 /**
  * @returns {JSX.Element} | A single users profile page
  */
 export default function DashboardScreen(): JSX.Element {
 	const { session } = useSessionContext();
-	const { user } = useUserContext();
-	const [profile, setProfile] = useState<Profile | null>(null);
+	const { profile, setProfile } = useProfileContext();
 	const [username, setUsername] = useState('');
 
 	useEffect(() => {
 		const handler = async () => {
-			if (user) {
-				const data = await getProfileById(user.id);
-				setProfile(data);
-				const queue = await getProfileWatchQueue(user.id);
+			if (session) {
+				const queue = await getProfileWatchQueue(session.user.id);
 				if (import.meta.env.DEV) console.log(queue);
 			}
 		};
 		handler();
-	}, [user]);
+	}, [session]);
 
 	const changeUsername = async () => {
-		if (user) {
-			const data = await updateProfileUsername(user.id, username);
+		if (session) {
+			const data = await updateProfileUsername(session.user.id, username);
 			setProfile(data);
 		}
 	};
 
 	const deleteProfile = async () => {
-		if (user) {
-			await deleteProfileById(user.id);
+		if (session) {
+			await deleteProfileById(session.user.id);
 			setProfile(null);
 		}
 	};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
-import type { User, Session } from './supabase';
+import type { User, Session, Profile } from './supabase';
 
 export type {
 	User,
-	Session
+	Session,
+	Profile
 };


### PR DESCRIPTION
# 🔍 Please Test

Creating this PR (as a draft rn) to get some more eyes on the authentication process. Instead of splitting the user out of the session, we now just have the session. You can still access the user via `session.user`. Then a profile context was added as well to show the data in the public DB.

A few specifics to check:

- Login
- Signup
- Browser close and refresh
- Account delete and rename
- Add to watch queue
- Logout

I also updated the pre-commit hook as it was not blocking the commit.

Let me know what you think here or on discord!