### PR TITLE
Fix bug where 'No providers' message flashes briefly on all screens

### DIFF
--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -11,6 +11,7 @@ interface ProviderProps {
  */
 export default function Providers(props: ProviderProps): JSX.Element {
     const [providers, setProviders] = useState<MovieProviders>();
+    const [loading, setLoading] = useState<boolean>(true);
 
     useEffect(() => {
         const handler = async () => {
@@ -18,13 +19,17 @@ export default function Providers(props: ProviderProps): JSX.Element {
                 const data = await getMovieProviders(props.id);
                 setProviders(data);
             }
+            setLoading(false);
         };
         handler();
     }, []);
 
+    // TODO: #210 Create loader component
+    if (loading) return <p>Loading</p>;
+
     return (
         <div className='flex justify-center'>
-            {providers?.results.US !== undefined ? (
+            {providers?.results?.US?.flatrate ? (
                 providers.results.US.flatrate.map((item, i) => (
                     <img
                         className='h-16 w-16'

--- a/src/types/tmdb.ts
+++ b/src/types/tmdb.ts
@@ -96,6 +96,20 @@ export interface MovieDetailsData extends MovieResultData {
     tagline: string;
 }
 
+interface ProviderInfo {
+    display_priority?: number;
+    logo_path?: string;
+    provider_id?: number;
+    provider_name?: string;
+}
+
+interface ProviderDetails {
+    link?: string;
+    flatrate?: ProviderInfo[];
+    rent?: ProviderInfo[];
+    buy?: ProviderInfo[];
+}
+
 export interface MovieProviders {
     id: number;
     results: {
@@ -142,36 +156,8 @@ export interface MovieProviders {
         SG?: ProviderDetails;
         TH?: ProviderDetails;
         TR?: ProviderDetails;
-        US: ProviderDetails;
+        US?: ProviderDetails;
         VE?: ProviderDetails;
         ZA?: ProviderDetails;
     };
-}
-
-export interface ProviderDetails {
-    link: string;
-    flatrate: [
-        {
-            display_priority: number;
-            logo_path: string;
-            provider_id: number;
-            provider_name: string;
-        }
-    ];
-    rent?: [
-        {
-            display_priority: number;
-            logo_path: string;
-            provider_id: number;
-            provider_name: string;
-        }
-    ];
-    buy?: [
-        {
-            display_priority: number;
-            logo_path: string;
-            provider_id: number;
-            provider_name: string;
-        }
-    ];
 }


### PR DESCRIPTION
Added loading state so nothing is returned until we have to correct provider data. Also made the type declarations all optional as this was causing errors if `US` existed, but `flatrate` did not.

fixes #195 