### PR TITLE
203 bug empty search

### DIFF
--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -26,6 +26,7 @@ export default function SearchInput(): JSX.Element {
                     inputProps={{
                         'data-testid': 'featured-search-input',
                     }}
+                    required
                     endAdornment={
                         <InputAdornment aria-label='submit search' position='end'>
                             <IconButton type='submit' data-testid='featured-search-button'>

--- a/src/screens/SearchResultsScreen.tsx
+++ b/src/screens/SearchResultsScreen.tsx
@@ -14,7 +14,10 @@ import { MovieData, MovieDetailsData } from '../types/tmdb';
 export async function loader({ request }: { request: Request }): Promise<string> {
     // get the query parameters from the URL
     const url = new URL(request.url);
-    const query = url.searchParams.get('q');
+    const query = url.searchParams.get('q')?.trim();
+    if (!query) {
+        throw new Response('Bad Request', { status: 400 });
+    }
     return query as string;
 }
 


### PR DESCRIPTION
Use vanilla HTML form validation to require the search input. Since this can be overridden client side, we also check for the input in the loader and throw an error if it does not exist. This causes the PageNotFound screen to be rendered. 

fixes #203 