### PR TITLE
114 Feature update queue buttons

### DIFF
--- a/src/__tests__/screens/movieScreen.test.tsx
+++ b/src/__tests__/screens/movieScreen.test.tsx
@@ -51,9 +51,6 @@ describe('Movie Screen Test Suite', async () => {
         expect(screen.getAllByRole('heading')[0]).toHaveTextContent('Search Results Page');
         // check for show card
         expect(screen.getAllByRole('heading')[1]).toHaveTextContent('Iron Man');
-        // check for queue buttons
-        expect(screen.getAllByRole('button')[2]).toHaveTextContent('Add to queue');
-        expect(screen.getAllByRole('button')[3]).toHaveTextContent('Remove from queue');
     });
     it('navigates to show details screen when show card is clicked on', async () => {
         // create a new data router for the test


### PR DESCRIPTION
Conditionally render add/remove queue buttons on show card based on profile state and data.

- If user is not logged in, no buttons are shown
- If user is logged in
    - & show is not in queue, "Add" button is shown
    - & show is in queue, "Remove" button is shown
- Removed check for buttons in test. These should be added to a subsequent test where we will log in. 

> NOTE: While the diff looks like there were big changes, this is mostly due to the fact I removed the JSX fragment, so everything was shifted over 4 spaces. The real changes start at line 102, plus the useEffect.

Closes #114 