### PR TITLE
99 feat gallery

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -18,6 +18,7 @@ import {
     DarkMode,
     ExpandLess,
     ExpandMore,
+    Explore,
     LightMode,
     Login,
     Logout,
@@ -205,6 +206,17 @@ export default function Navigation(props: NavProps): JSX.Element {
                                 </div>
                             )}
                             <Divider />
+                            <MenuItem
+                                className='!p-2'
+                                onClick={() => toggleUserMenu(null, false)}
+                                component={Link}
+                                to='/discover'
+                            >
+                                <ListItemIcon className='!text-text'>
+                                    <Explore className='mr-2' />
+                                    Discover
+                                </ListItemIcon>
+                            </MenuItem>
                             <MenuItem className='!p-2' onClick={themeSwitcher}>
                                 <ListItemIcon className='!text-text'>
                                     {themeIcon}

--- a/src/helpers/getMovieUtils.ts
+++ b/src/helpers/getMovieUtils.ts
@@ -39,4 +39,17 @@ const getMovieProviders = async (id: number): Promise<MovieProviders> => {
     return response.json() as Promise<MovieProviders>;
 };
 
-export { getMoviesByName, getMovieDetails, getMovieProviders };
+/**
+ * This function returns trending movies, tv shows, or both. /all instead of /movie will alter its behavior. Similarly, /day instead of /week will return daily trending.
+ * @returns @returns {Promise<MovieData>} | Trending Movies & TV Shows
+ */
+const getTrending = async (): Promise<MovieData> => {
+    const response = await fetch(
+        `https://api.themoviedb.org/3/trending/movie/week?api_key=${
+            import.meta.env.VITE_MOVIEDB_KEY
+        }`
+    );
+    return response.json() as Promise<MovieData>;
+};
+
+export { getMoviesByName, getMovieDetails, getMovieProviders, getTrending };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import {
     DashboardScreen,
     AuthScreen,
     ShowDetailsScreen,
+    DiscoverScreen,
 } from './screens';
 import { loader as searchLoader } from './screens/SearchResultsScreen';
 import { LoginForm, SignUpForm } from './components';
@@ -54,6 +55,10 @@ const router = createBrowserRouter([
             {
                 path: 'details/:id',
                 element: <ShowDetailsScreen />,
+            },
+            {
+                path: 'discover',
+                element: <DiscoverScreen />,
             },
         ],
     },

--- a/src/screens/DiscoverScreen.tsx
+++ b/src/screens/DiscoverScreen.tsx
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+import { getTrending, getMovieDetails } from '../helpers/getMovieUtils';
+import { MovieDetailsData, MovieData } from '../types/tmdb';
+import { ShowCard } from '../components';
+/**
+ * Requests trending movies, passing data to ShowCard components.
+ * @returns {JSX.Element}
+ */
+export default function DiscoverScreen(): JSX.Element {
+    const [trending, setTrending] = useState<MovieDetailsData[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    useEffect(() => {
+        const handler = async () => {
+            const movieData: MovieData = await getTrending();
+            const movieArr = [];
+            for (let i = 0; i < movieData.results.length; i++) {
+                const movie = await getMovieDetails(movieData.results[i].id);
+                movieArr.push(movie);
+            }
+            setTrending(movieArr);
+            setLoading(false);
+        };
+        handler();
+    }, []);
+
+    // TODO: #194 Make skeleton loading screen
+    if (loading) return <p>Loading...</p>;
+
+    return <div>{trending.map((item, i) => item && <ShowCard key={i} details={item} />)}</div>;
+}

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -9,6 +9,7 @@ import PageNotFoundScreen from './PageNotFoundScreen';
 import DashboardScreen from './DashboardScreen';
 import ShowDetailsScreen from './ShowDetailsScreen';
 import AuthScreen from './AuthScreen';
+import DiscoverScreen from './DiscoverScreen';
 
 export {
     FeaturedSearchScreen,
@@ -17,4 +18,5 @@ export {
     DashboardScreen,
     ShowDetailsScreen,
     AuthScreen,
+    DiscoverScreen,
 };


### PR DESCRIPTION
Created DiscoverScreen component that requests trending movies from MDB. This can be changed to include TV Shows further along as everything rounds out. 

Request looks like: 
```
https://api.themoviedb.org/3/trending/<type>/<time>?api_key=
```
`type` accepts `all`, `movie`, `tv`, or `person`. 
`time` accepts `day`, or `week`.
I envision these parameters will be user controlled with filters.

See #100 for future filters to be added.

Closes #99 