### PR TITLE
199 test invalid auth

### DIFF
--- a/src/__tests__/helpers/navigation.ts
+++ b/src/__tests__/helpers/navigation.ts
@@ -13,4 +13,18 @@ const goHome = async (user: UserEvent) => {
     await waitFor(() => screen.getByTestId('featured-search-heading'));
 };
 
-export { openMenu, goHome };
+// navigate to login screen
+const goToLogin = async (user: UserEvent) => {
+    await openMenu(user);
+    await user.click(screen.getByText('Login'));
+    await waitFor(() => screen.getByTestId('login-heading'));
+};
+
+// navigate to sign up screen
+const goToSignUp = async (user: UserEvent) => {
+    await openMenu(user);
+    await user.click(screen.getByText('Sign Up'));
+    await waitFor(() => screen.getByTestId('signup-heading'));
+};
+
+export { openMenu, goHome, goToLogin, goToSignUp };

--- a/src/__tests__/screens/authScreen.test.tsx
+++ b/src/__tests__/screens/authScreen.test.tsx
@@ -1,17 +1,18 @@
 import '@testing-library/jest-dom';
-import { render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { routes } from '../routes';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { UserEvent } from '@testing-library/user-event/dist/types/setup/setup';
-import { goHome, openMenu } from '../helpers/navigation';
+import { goHome, goToLogin, goToSignUp } from '../helpers/navigation';
 
 describe('Auth Screen Test Suite', async () => {
     // set up variables to be used on each test
     let user: UserEvent;
     beforeEach(() => {
-        user = userEvent.setup();
+        vi.useFakeTimers();
+        user = userEvent.setup({ advanceTimers: () => vi.advanceTimersByTime(1) });
     });
 
     it('navigates to login and sign up screen from homepage', async () => {
@@ -23,22 +24,71 @@ describe('Auth Screen Test Suite', async () => {
         render(<RouterProvider router={router} />);
 
         await waitFor(() => screen.getByTestId('featured-search-heading'));
-        await openMenu(user);
-        // navigate to login
-        await user.click(screen.getByText('Login'));
-        await waitFor(() => screen.getByTestId('login-heading'));
+        await goToLogin(user);
         expect(screen.getByTestId('login-form')).toBeInTheDocument();
         expect(screen.getByText('Password')).toBeInTheDocument();
         expect(screen.getByText('Email')).toBeInTheDocument();
         await goHome(user);
-        await openMenu(user);
-        // navigate to sign up
-        await user.click(screen.getByText('Sign Up'));
-        await waitFor(() => screen.getByTestId('signup-heading'));
+        await goToSignUp(user);
         expect(screen.getByTestId('signup-form')).toBeInTheDocument();
         expect(screen.getByText('Email')).toBeInTheDocument();
         expect(screen.getByText('Password')).toBeInTheDocument();
         expect(screen.getByText('Confirm Password')).toBeInTheDocument();
         expect(screen.getByText('Username')).toBeInTheDocument();
+    });
+    it('does not allow submission of incomplete login form', async () => {
+        // create a new data router for the test
+        const router = createMemoryRouter(routes, {
+            initialEntries: ['/'],
+        });
+        // render screens
+        render(<RouterProvider router={router} />);
+
+        await waitFor(() => screen.getByTestId('featured-search-heading'));
+        await goToLogin(user);
+        const submitBtn = screen.getByText('Submit');
+        // empty form
+        await user.click(submitBtn);
+        const errorMsg = screen.getByTestId('error-message-message');
+        expect(errorMsg).toBeInTheDocument();
+        expect(errorMsg.textContent).toBe('Error! All fields must be filled out');
+        act(() => {
+            vi.runAllTimers();
+        });
+        expect(screen.queryByTestId('error-message-message')).not.toBeInTheDocument();
+        // incomplete form
+        await user.type(screen.getByLabelText('Email'), 'invalid@email');
+        await user.click(submitBtn);
+        expect(screen.getByTestId('error-message-message')).toBeInTheDocument();
+        expect(errorMsg.textContent).toBe('Error! All fields must be filled out');
+        act(() => {
+            vi.runAllTimers();
+        });
+        expect(screen.queryByTestId('error-message-message')).not.toBeInTheDocument();
+        await user.clear(screen.getByLabelText('Email'));
+        await user.type(screen.getByLabelText('Password'), 'password');
+        await user.click(submitBtn);
+        expect(screen.getByTestId('error-message-message')).toBeInTheDocument();
+        expect(errorMsg.textContent).toBe('Error! All fields must be filled out');
+    });
+    it('does not allow submission of invalid email address', async () => {
+        // create a new data router for the test
+        const router = createMemoryRouter(routes, {
+            initialEntries: ['/'],
+        });
+        // render screens
+        render(<RouterProvider router={router} />);
+
+        await waitFor(() => screen.getByTestId('featured-search-heading'));
+        await goToLogin(user);
+        const submitBtn = screen.getByText('Submit');
+
+        // invalid email
+        await user.type(screen.getByTestId('login-email-input'), 'invalid@email');
+        await user.type(screen.getByTestId('login-password-input'), 'password');
+        await user.click(submitBtn);
+        const errorMsg = screen.getByTestId('error-message-message');
+        expect(screen.getByTestId('error-message-message')).toBeInTheDocument();
+        expect(errorMsg.textContent).toBe('Error! Must provide valid email');
     });
 });

--- a/src/__tests__/screens/authScreen.test.tsx
+++ b/src/__tests__/screens/authScreen.test.tsx
@@ -36,6 +36,7 @@ describe('Auth Screen Test Suite', async () => {
         expect(screen.getByText('Confirm Password')).toBeInTheDocument();
         expect(screen.getByText('Username')).toBeInTheDocument();
     });
+
     it('does not allow submission of incomplete login form', async () => {
         // create a new data router for the test
         const router = createMemoryRouter(routes, {
@@ -49,9 +50,10 @@ describe('Auth Screen Test Suite', async () => {
         const submitBtn = screen.getByText('Submit');
         // empty form
         await user.click(submitBtn);
-        const errorMsg = screen.getByTestId('error-message-message');
-        expect(errorMsg).toBeInTheDocument();
-        expect(errorMsg.textContent).toBe('Error! All fields must be filled out');
+        expect(screen.getByTestId('error-message-message')).toBeInTheDocument();
+        expect(screen.getByTestId('error-message-message').textContent).toBe(
+            'Error! All fields must be filled out'
+        );
         act(() => {
             vi.runAllTimers();
         });
@@ -60,7 +62,9 @@ describe('Auth Screen Test Suite', async () => {
         await user.type(screen.getByLabelText('Email'), 'invalid@email');
         await user.click(submitBtn);
         expect(screen.getByTestId('error-message-message')).toBeInTheDocument();
-        expect(errorMsg.textContent).toBe('Error! All fields must be filled out');
+        expect(screen.getByTestId('error-message-message').textContent).toBe(
+            'Error! All fields must be filled out'
+        );
         act(() => {
             vi.runAllTimers();
         });
@@ -69,9 +73,12 @@ describe('Auth Screen Test Suite', async () => {
         await user.type(screen.getByLabelText('Password'), 'password');
         await user.click(submitBtn);
         expect(screen.getByTestId('error-message-message')).toBeInTheDocument();
-        expect(errorMsg.textContent).toBe('Error! All fields must be filled out');
+        expect(screen.getByTestId('error-message-message').textContent).toBe(
+            'Error! All fields must be filled out'
+        );
     });
-    it('does not allow submission of invalid email address', async () => {
+
+    it('does not allow submission of login form with invalid email address', async () => {
         // create a new data router for the test
         const router = createMemoryRouter(routes, {
             initialEntries: ['/'],
@@ -81,14 +88,102 @@ describe('Auth Screen Test Suite', async () => {
 
         await waitFor(() => screen.getByTestId('featured-search-heading'));
         await goToLogin(user);
-        const submitBtn = screen.getByText('Submit');
-
-        // invalid email
-        await user.type(screen.getByTestId('login-email-input'), 'invalid@email');
-        await user.type(screen.getByTestId('login-password-input'), 'password');
-        await user.click(submitBtn);
-        const errorMsg = screen.getByTestId('error-message-message');
+        await user.type(screen.getByLabelText('Email'), 'invalid@email');
+        await user.type(screen.getByLabelText('Password'), 'password');
+        await user.click(screen.getByText('Submit'));
         expect(screen.getByTestId('error-message-message')).toBeInTheDocument();
-        expect(errorMsg.textContent).toBe('Error! Must provide valid email');
+        expect(screen.getByTestId('error-message-message').textContent).toBe(
+            'Error! Must provide valid email'
+        );
+    });
+
+    it('does not allow submission of incomplete sign up form', async () => {
+        const router = createMemoryRouter(routes, {
+            initialEntries: ['/'],
+        });
+        // render screens
+        render(<RouterProvider router={router} />);
+
+        await waitFor(() => screen.getByTestId('featured-search-heading'));
+        await goToSignUp(user);
+        const submitBtn = screen.getByText('Submit');
+        // empty form
+        await user.click(submitBtn);
+        expect(screen.getByTestId('error-message-message')).toBeInTheDocument();
+        expect(screen.getByTestId('error-message-message').textContent).toBe(
+            'Error! All fields must be filled out'
+        );
+        act(() => {
+            vi.runAllTimers();
+        });
+        expect(screen.queryByTestId('error-message-message')).not.toBeInTheDocument();
+        // incomplete form
+        await user.type(screen.getByLabelText('Email'), 'invalid@email');
+        await user.click(submitBtn);
+        expect(screen.getByTestId('error-message-message')).toBeInTheDocument();
+        expect(screen.getByTestId('error-message-message').textContent).toBe(
+            'Error! All fields must be filled out'
+        );
+        act(() => {
+            vi.runAllTimers();
+        });
+        expect(screen.queryByTestId('error-message-message')).not.toBeInTheDocument();
+        await user.type(screen.getByLabelText('Username'), 'testname');
+        await user.click(submitBtn);
+        expect(screen.getByTestId('error-message-message')).toBeInTheDocument();
+        expect(screen.getByTestId('error-message-message').textContent).toBe(
+            'Error! All fields must be filled out'
+        );
+        act(() => {
+            vi.runAllTimers();
+        });
+        expect(screen.queryByTestId('error-message-message')).not.toBeInTheDocument();
+        await user.type(screen.getByLabelText('Password'), 'password');
+        await user.click(submitBtn);
+        expect(screen.getByTestId('error-message-message')).toBeInTheDocument();
+        expect(screen.getByTestId('error-message-message').textContent).toBe(
+            'Error! All fields must be filled out'
+        );
+    });
+
+    it('does not allow submission of sign up form with invalid email address', async () => {
+        // create a new data router for the test
+        const router = createMemoryRouter(routes, {
+            initialEntries: ['/'],
+        });
+        // render screens
+        render(<RouterProvider router={router} />);
+
+        await waitFor(() => screen.getByTestId('featured-search-heading'));
+        await goToSignUp(user);
+        await user.type(screen.getByLabelText('Email'), 'invalid@email');
+        await user.type(screen.getByLabelText('Username'), 'testname');
+        await user.type(screen.getByLabelText('Password'), 'password');
+        await user.type(screen.getByLabelText('Confirm Password'), 'drowssap');
+        await user.click(screen.getByText('Submit'));
+        expect(screen.getByTestId('error-message-message')).toBeInTheDocument();
+        expect(screen.getByTestId('error-message-message').textContent).toBe(
+            'Error! Must provide valid email'
+        );
+    });
+
+    it('does not allow submission of sign up form with non-matching passwords', async () => {
+        const router = createMemoryRouter(routes, {
+            initialEntries: ['/'],
+        });
+        // render screens
+        render(<RouterProvider router={router} />);
+
+        await waitFor(() => screen.getByTestId('featured-search-heading'));
+        await goToSignUp(user);
+        await user.type(screen.getByLabelText('Email'), 'valid@email.com');
+        await user.type(screen.getByLabelText('Username'), 'testname');
+        await user.type(screen.getByLabelText('Password'), 'password');
+        await user.type(screen.getByLabelText('Confirm Password'), 'drowssap');
+        await user.click(screen.getByText('Submit'));
+        expect(screen.getByTestId('error-message-message')).toBeInTheDocument();
+        expect(screen.getByTestId('error-message-message').textContent).toBe(
+            'Error! Passwords must match'
+        );
     });
 });

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -94,9 +94,6 @@ export default function LoginForm(): JSX.Element {
                         autoComplete='email'
                         color='secondary'
                         value={email}
-                        inputProps={{
-                            'data-testid': 'login-email-input',
-                        }}
                         error={emailError}
                         onChange={(e) => setEmail(e.target.value)}
                         onFocus={() => setEmailError(false)}
@@ -114,9 +111,6 @@ export default function LoginForm(): JSX.Element {
                         value={password}
                         error={passwordError}
                         color='secondary'
-                        inputProps={{
-                            'data-testid': 'login-password-input',
-                        }}
                         onChange={(e) => setPassword(e.target.value)}
                         onFocus={() => setPasswordError(false)}
                         endAdornment={

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -94,6 +94,9 @@ export default function LoginForm(): JSX.Element {
                         autoComplete='email'
                         color='secondary'
                         value={email}
+                        inputProps={{
+                            'data-testid': 'login-email-input',
+                        }}
                         error={emailError}
                         onChange={(e) => setEmail(e.target.value)}
                         onFocus={() => setEmailError(false)}
@@ -111,6 +114,9 @@ export default function LoginForm(): JSX.Element {
                         value={password}
                         error={passwordError}
                         color='secondary'
+                        inputProps={{
+                            'data-testid': 'login-password-input',
+                        }}
                         onChange={(e) => setPassword(e.target.value)}
                         onFocus={() => setPasswordError(false)}
                         endAdornment={

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -91,7 +91,7 @@ export default function SignUpForm(): JSX.Element {
             setConfirmPasswordError(true);
         }
         if (!email || !password || !confirmPassword || !username) {
-            showError('All fields must be filled out.');
+            showError('All fields must be filled out');
             return;
         }
 
@@ -113,7 +113,7 @@ export default function SignUpForm(): JSX.Element {
         if (password !== confirmPassword) {
             setPasswordError(true);
             setConfirmPasswordError(true);
-            showError('Passwords must match.');
+            showError('Passwords must match');
             return;
         }
 


### PR DESCRIPTION
Created tests for almost all cases of invalid login and signup data. This includes:

- Incomplete forms
- Invalid email
- Non-matching passwords

I also implemented the `fakeTimers` method so we do not have to wait 3 seconds for the error message to disappear.
- #199 