### PR TITLE
Add NO_VERIFY flag check to pre-commit hook. Update docs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,6 +5,11 @@
 # exit with non-zero status after issuing an appropriate message if
 # it wants to stop the commit.
 
+if [ "$NO_VERIFY" ]; then
+    printf "\033[41m ⚠️  pre-commit hook skipped\033[0m\n"
+    exit 0
+fi
+
 echo "--- Building App ---"
 npm run build
 if [[ "$?" == 0 ]]; then

--- a/docs/contribution-guidelines.md
+++ b/docs/contribution-guidelines.md
@@ -92,6 +92,17 @@ git push -f origin branch-name
 ```
 > NOTE: `HEAD~2` would pick the current HEAD and on commit previous for the rebase. Change this number as needed depending on the number of commits you have. You can read more about rebasing [here](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
 
+## Work-in-Progress Commits
+
+If you would like to make commits without running the full test suite, you can do so with the following command:
+```s
+git commit -m "msg" --no-verify
+```
+You can also set an enviornment flag in you shell to do this. Here is a helpful script for quickly creating WIP commits:
+```s
+export NO_VERIFY=1 && git add -A && git commit -m "CI Skipped. --WIP--" && export NO_VERIFY=
+```
+
 # Code Quality 🧼
 
 ## ES Lint


### PR DESCRIPTION
Made it a bit easier to skip the pre-commit hook. This is especially useful if you are rebasing a number of no-verify commits with a verified commit. 

## Usage

Run `export NO_VERIFY=1` in your shell to set an env variable. This will be picked up by the pre-commit hook and skip it. 
Run `export NO_VERIFY=` in your shell to clear the env variable.

If you are not already using oh-my-zsh, you can now created your own `gwip` alias. Add the following to your shell rc file:
```
alias gwip="export NO_VERIFY=1 && git add -A && git commit -m \"CI Skipped. --WIP--\" && export NO_VERIFY="
```

Closes #240 