### PR TITLE
227 feat tv req

### DIFF
--- a/src/__tests__/routes.tsx
+++ b/src/__tests__/routes.tsx
@@ -12,7 +12,7 @@ import { loader as searchLoader } from '../screens/SearchResultsScreen';
 import 'react-router-dom';
 import { RouteObject } from 'react-router-dom';
 import sampleMovieData from './screens/assets/movieData.json';
-import { MovieDetailsData } from '../types/tmdb';
+import { ShowData } from '../types/tmdb';
 
 /**
  * Routes to be used in screen unit tests
@@ -70,7 +70,7 @@ export const showCardRoutes: RouteObject[] = [
         children: [
             {
                 path: '/',
-                element: <ShowCard details={sampleMovieData as MovieDetailsData} />,
+                element: <ShowCard details={sampleMovieData as ShowData} />,
             },
         ],
     },

--- a/src/__tests__/screens/assets/showData.json
+++ b/src/__tests__/screens/assets/showData.json
@@ -1,0 +1,11 @@
+{
+    "id": 1726,
+    "poster_path": "/78lPtwv72eTNqFW9COBYI0dWDJa.jpg",
+    "title": "Iron Man",
+    "release_date": "2008-04-30",
+    "age_rating": "PG-13",
+    "runtime": 126,
+    "vote_average": 7.631,
+    "vote_count": 23740,
+    "overview": "After being held captive in an Afghan cave, billionaire engineer Tony Stark creates a unique weaponized suit of armor to fight evil."
+}

--- a/src/__tests__/screens/movieScreen.test.tsx
+++ b/src/__tests__/screens/movieScreen.test.tsx
@@ -9,12 +9,12 @@ import { UserEvent } from '@testing-library/user-event/dist/types/setup/setup';
 // mock MovieDB API calls
 vi.mock('../../helpers/getMovieUtils', () => {
     const sampleMovieData = vi.importActual('./assets/searchData.json');
-    const sampleMovieDetailsData = vi.importActual('./assets/movieData.json');
     const sampleMovieProviders = vi.importActual('./assets/providerData.json');
+    const sampleShowData = vi.importActual('./assets/showData.json');
     return {
         default: {},
         getMoviesByName: vi.fn().mockResolvedValue(sampleMovieData),
-        getMovieDetails: vi.fn().mockResolvedValue(sampleMovieDetailsData),
+        getMovieDetails: vi.fn().mockResolvedValue(sampleShowData),
         getMovieProviders: vi.fn().mockResolvedValue(sampleMovieProviders),
     };
 });

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -24,6 +24,8 @@ export default function Providers(props: ProviderProps): JSX.Element {
         handler();
     }, []);
 
+    console.log(providers);
+
     // TODO: #210 Create loader component
     if (loading) return <p>Loading</p>;
 

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,30 +1,32 @@
 import { useEffect, useState } from 'react';
-import { MovieProviders } from '../types/tmdb';
+import { ShowProviders, ShowData } from '../types/tmdb';
 import { getMovieProviders } from '../helpers/getMovieUtils';
+import { getTvProviders } from '../helpers/getShowUtils';
 
 interface ProviderProps {
-    id: number;
+    details: ShowData;
 }
 /**
  * Component to display streaming services logos for a given movie or show. Accepts an ID and
  * @returns {JSX.Element}
  */
-export default function Providers(props: ProviderProps): JSX.Element {
-    const [providers, setProviders] = useState<MovieProviders>();
+export default function Providers({ details }: ProviderProps): JSX.Element {
+    const [providers, setProviders] = useState<ShowProviders>();
     const [loading, setLoading] = useState<boolean>(true);
 
     useEffect(() => {
         const handler = async () => {
-            if (props.id) {
-                const data = await getMovieProviders(props.id);
+            if (details.id && details.networks === undefined) {
+                const data = await getMovieProviders(details.id);
+                setProviders(data);
+            } else if (details.id && details.networks !== undefined) {
+                const data = await getTvProviders(details.id);
                 setProviders(data);
             }
             setLoading(false);
         };
         handler();
     }, []);
-
-    console.log(providers);
 
     // TODO: #210 Create loader component
     if (loading) return <p>Loading</p>;

--- a/src/components/ShowCard.tsx
+++ b/src/components/ShowCard.tsx
@@ -4,15 +4,15 @@ import {
     getProfileWatchQueue,
     removeFromProfileWatchQueue,
 } from '../supabase/profiles';
-import { MovieDetailsData } from '../types/tmdb';
+import { ShowData } from '../types/tmdb';
 import { Link } from 'react-router-dom';
 import { formatReleaseDate, DateSize } from '../helpers/dateFormatUtils';
 import { useEffect, useState } from 'react';
 import { Button, CardActions, CardContent, CardMedia, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 
-interface MovieCardProps {
-    details: MovieDetailsData;
+interface CardProps {
+    details: ShowData;
 }
 
 /**
@@ -23,21 +23,9 @@ interface MovieCardProps {
  * @param props | returns details object passed from SearchResultScreen.tsx
  * @returns {JSX.Element} | Single show card
  */
-export default function ShowCard(props: MovieCardProps): JSX.Element {
+export default function ShowCard(props: CardProps): JSX.Element {
     const { profile, setProfile } = useProfileContext();
     const [isInWatchQueue, setIsInWatchQueue] = useState<boolean>(false);
-
-    const ratingHandler = (arr: MovieDetailsData): string => {
-        for (let i = 0; i < arr.release_dates.results.length; i++) {
-            if (
-                arr.release_dates.results[i].iso_3166_1 === 'US' &&
-                arr.release_dates.results[i].release_dates[0].certification
-            ) {
-                return arr.release_dates.results[i].release_dates[0].certification;
-            }
-        }
-        return 'No rating available';
-    };
 
     /**
      * On component render, get the current users watch queue from Supabase
@@ -87,10 +75,8 @@ export default function ShowCard(props: MovieCardProps): JSX.Element {
                         alt={`${props.details.original_title} poster`}
                     />
                 )}
-            </Link>
-            <Box sx={{ display: 'flex', flexDirection: 'column', margin: 'auto' }}>
-                <CardContent>
-                    <Typography variant='h5'>{props.details.original_title}</Typography>
+                <div>
+                    <h2>{props.details.title}</h2>
                     {props.details.release_date.length === 10 && (
                         <Typography>
                             {formatReleaseDate(props.details.release_date, DateSize.MEDIUM)}
@@ -98,36 +84,21 @@ export default function ShowCard(props: MovieCardProps): JSX.Element {
                     )}
                     <Typography variant='body2'>{props.details.runtime} minutes</Typography>
                     {/* TODO: #152 Include number of stars with styling, response returns rating out of 10  */}
-                    <Typography variant='body2'>{props.details.vote_average} stars</Typography>
-                    <Typography variant='body2'>{props.details.vote_count} ratings</Typography>
-                    <Typography variant='body2'>{ratingHandler(props.details)}</Typography>
-                </CardContent>
-                {profile && (
-                    <CardActions sx={{ margin: 'auto', display: 'flex', flexDirection: 'column' }}>
-                        {isInWatchQueue ? (
-                            <Button
-                                sx={{ m: 1 }}
-                                variant='outlined'
-                                size='small'
-                                color='secondary'
-                                onClick={() => queueHandler(true, props.details?.id)}
-                            >
-                                Add to queue
-                            </Button>
-                        ) : (
-                            <Button
-                                sx={{ m: 1 }}
-                                variant='outlined'
-                                size='small'
-                                color='secondary'
-                                onClick={() => queueHandler(false, props.details?.id)}
-                            >
-                                Remove from queue
-                            </Button>
-                        )}
-                    </CardActions>
-                )}
-            </Box>
+                    <p>{props.details.vote_average} stars</p>
+                    <span>{props.details.vote_count} ratings</span>
+                    <p>{props.details.age_rating}</p>
+                </div>
+            </Link>
+            {profile &&
+                (isInWatchQueue ? (
+                    <button onClick={() => queueHandler(false, props.details?.id)}>
+                        Remove from queue
+                    </button>
+                ) : (
+                    <button onClick={() => queueHandler(true, props.details?.id)}>
+                        Add to queue
+                    </button>
+                ))}
         </div>
     );
 }

--- a/src/components/ShowCard.tsx
+++ b/src/components/ShowCard.tsx
@@ -11,7 +11,7 @@ import { useEffect, useState } from 'react';
 import { Button, CardActions, CardContent, CardMedia, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 
-interface CardProps {
+interface MovieCardProps {
     details: ShowData;
 }
 
@@ -23,7 +23,7 @@ interface CardProps {
  * @param props | returns details object passed from SearchResultScreen.tsx
  * @returns {JSX.Element} | Single show card
  */
-export default function ShowCard(props: CardProps): JSX.Element {
+export default function ShowCard({ details }: MovieCardProps): JSX.Element {
     const { profile, setProfile } = useProfileContext();
     const [isInWatchQueue, setIsInWatchQueue] = useState<boolean>(false);
 
@@ -34,7 +34,7 @@ export default function ShowCard(props: CardProps): JSX.Element {
     useEffect(() => {
         const handler = async () => {
             const currentWatchQueue = profile ? await getProfileWatchQueue(profile.id) : null;
-            if (currentWatchQueue && currentWatchQueue.includes(props.details.id)) {
+            if (currentWatchQueue && currentWatchQueue.includes(details.id)) {
                 setIsInWatchQueue(true);
             }
         };
@@ -64,41 +64,58 @@ export default function ShowCard(props: CardProps): JSX.Element {
 
     return (
         <div data-testid='show-card-component' className='m-1 flex w-96 bg-foreground'>
-            <Link to={`/details/${props.details.id}`} state={props} data-testid='show-details-link'>
+            <Link to={`/details/${details.id}`} state={details} data-testid='show-details-link'>
                 {/* TODO: #193 Add placeholder poster if null */}
-                {props.details.poster_path && (
+                {details.poster_path && (
                     <CardMedia
                         component='img'
                         className='w-full cursor-pointer'
                         sx={{ width: 180, minWidth: 180, height: 270, minHeight: 270 }}
-                        image={`https://image.tmdb.org/t/p/w500${props.details.poster_path}`}
-                        alt={`${props.details.original_title} poster`}
+                        image={`https://image.tmdb.org/t/p/w500${details.poster_path}`}
+                        alt={`${details.title} poster`}
                     />
                 )}
-                <div>
-                    <h2>{props.details.title}</h2>
-                    {props.details.release_date.length === 10 && (
+            </Link>
+            <Box sx={{ display: 'flex', flexDirection: 'column', margin: 'auto' }}>
+                <CardContent>
+                    <Typography variant='h5'>{details.title}</Typography>
+                    {details.release_date.length === 10 && (
                         <Typography>
-                            {formatReleaseDate(props.details.release_date, DateSize.MEDIUM)}
+                            {formatReleaseDate(details.release_date, DateSize.MEDIUM)}
                         </Typography>
                     )}
-                    <Typography variant='body2'>{props.details.runtime} minutes</Typography>
+                    <Typography variant='body2'>{details.runtime} minutes</Typography>
                     {/* TODO: #152 Include number of stars with styling, response returns rating out of 10  */}
-                    <p>{props.details.vote_average} stars</p>
-                    <span>{props.details.vote_count} ratings</span>
-                    <p>{props.details.age_rating}</p>
-                </div>
-            </Link>
-            {profile &&
-                (isInWatchQueue ? (
-                    <button onClick={() => queueHandler(false, props.details?.id)}>
-                        Remove from queue
-                    </button>
-                ) : (
-                    <button onClick={() => queueHandler(true, props.details?.id)}>
-                        Add to queue
-                    </button>
-                ))}
+                    <Typography variant='body2'>{details.vote_average} stars</Typography>
+                    <Typography variant='body2'>{details.vote_count} ratings</Typography>
+                    <Typography variant='body2'>{details.age_rating}</Typography>
+                </CardContent>
+                {profile && (
+                    <CardActions sx={{ margin: 'auto', display: 'flex', flexDirection: 'column' }}>
+                        {isInWatchQueue ? (
+                            <Button
+                                sx={{ m: 1 }}
+                                variant='outlined'
+                                size='small'
+                                color='secondary'
+                                onClick={() => queueHandler(true, details?.id)}
+                            >
+                                Add to queue
+                            </Button>
+                        ) : (
+                            <Button
+                                sx={{ m: 1 }}
+                                variant='outlined'
+                                size='small'
+                                color='secondary'
+                                onClick={() => queueHandler(false, details?.id)}
+                            >
+                                Remove from queue
+                            </Button>
+                        )}
+                    </CardActions>
+                )}
+            </Box>
         </div>
     );
 }

--- a/src/helpers/getMovieUtils.ts
+++ b/src/helpers/getMovieUtils.ts
@@ -1,4 +1,4 @@
-import { MovieData, MovieDetailsData, MovieProviders } from '../types/tmdb';
+import { MovieData, MovieDetailsData, MovieProviders, ShowData } from '../types/tmdb';
 
 /**
  * This function is ran after the user enters a name of a movie.
@@ -17,13 +17,33 @@ const getMoviesByName = async (name: string): Promise<MovieData> => {
  * This function is ran for specific <ShowCard /> data with a movieID.
  * @returns {Promise<MovieDetailsData>} | Specific data for a movie that is not originally supplied by getMoviesByName.
  */
-const getMovieDetails = async (id: number): Promise<MovieDetailsData> => {
+const getMovieDetails = async (id: number): Promise<ShowData> => {
     const response = await fetch(
         `https://api.themoviedb.org/3/movie/${id}?api_key=${
             import.meta.env.VITE_MOVIEDB_KEY
         }&append_to_response=images,release_dates`
     );
-    return response.json() as Promise<MovieDetailsData>;
+    const data = (await response.json()) as MovieDetailsData;
+    const returnRating = async (arr: MovieDetailsData) => {
+        for (let i = 0; i < arr.release_dates.results.length; i++) {
+            if (arr.release_dates.results[i].iso_3166_1 === 'US') {
+                return arr.release_dates.results[i].release_dates[0].certification;
+            }
+        }
+        return null;
+    };
+    const obj: ShowData = {
+        id: data.id,
+        poster_path: data.poster_path,
+        title: data.original_title,
+        release_date: data.release_date,
+        age_rating: await returnRating(data),
+        runtime: data.runtime,
+        vote_average: data.vote_average,
+        vote_count: data.vote_count,
+        overview: data.overview,
+    };
+    return obj;
 };
 
 /**

--- a/src/helpers/getMovieUtils.ts
+++ b/src/helpers/getMovieUtils.ts
@@ -1,4 +1,4 @@
-import { MovieData, MovieDetailsData, MovieProviders, ShowData } from '../types/tmdb';
+import { MovieData, MovieDetailsData, ShowProviders, ShowData } from '../types/tmdb';
 
 /**
  * This function is ran after the user enters a name of a movie.
@@ -24,44 +24,43 @@ const getMovieDetails = async (id: number): Promise<ShowData> => {
         }&append_to_response=images,release_dates`
     );
     const data = (await response.json()) as MovieDetailsData;
-    const returnRating = async (arr: MovieDetailsData) => {
+    const returnRating = (arr: MovieDetailsData) => {
         for (let i = 0; i < arr.release_dates.results.length; i++) {
             if (arr.release_dates.results[i].iso_3166_1 === 'US') {
                 return arr.release_dates.results[i].release_dates[0].certification;
             }
         }
-        return null;
+        return 'No rating available';
     };
-    const obj: ShowData = {
+    return {
         id: data.id,
         poster_path: data.poster_path,
         title: data.original_title,
         release_date: data.release_date,
-        age_rating: await returnRating(data),
+        age_rating: returnRating(data),
         runtime: data.runtime,
         vote_average: data.vote_average,
         vote_count: data.vote_count,
         overview: data.overview,
-    };
-    return obj;
+    } as ShowData;
 };
 
 /**
- * This function is ran for a specified movie to return streaming services with a movieID.
- * @returns {Promise<MovieDetailsData>} | Specific data for a movie that is not originally supplied by getMoviesByName.
+ * This function is ran for a specified movie to return streaming services with a Movie ID.
+ * @returns {Promise<ShowProviders>} | Returns list of streaming services.
  */
-const getMovieProviders = async (id: number): Promise<MovieProviders> => {
+const getMovieProviders = async (id: number): Promise<ShowProviders> => {
     const response = await fetch(
         `https://api.themoviedb.org/3/movie/${id}/watch/providers?api_key=${
             import.meta.env.VITE_MOVIEDB_KEY
         }`
     );
-    return response.json() as Promise<MovieProviders>;
+    return response.json() as Promise<ShowProviders>;
 };
 
 /**
  * This function returns trending movies, tv shows, or both. /all instead of /movie will alter its behavior. Similarly, /day instead of /week will return daily trending.
- * @returns @returns {Promise<MovieData>} | Trending Movies & TV Shows
+ * @returns {Promise<MovieData>} | Trending Movies & TV Shows
  */
 const getTrending = async (): Promise<MovieData> => {
     const response = await fetch(

--- a/src/helpers/getShowUtils.ts
+++ b/src/helpers/getShowUtils.ts
@@ -1,0 +1,50 @@
+import { ShowData, TvShowDetailsData, TvShowData } from '../types/tmdb';
+
+/**
+ * This function is ran after the user enters a name of a TV Show.
+ * @returns {Promise<MovieData>} | List of shows by searched query.
+ */
+const getShowsByName = async (name: string): Promise<TvShowData> => {
+    const response = await fetch(
+        `https://api.themoviedb.org/3/search/tv?api_key=${
+            import.meta.env.VITE_MOVIEDB_KEY
+        }&language=en-US&query=${name}&page=1&include_adult=false`
+    );
+    return response.json() as Promise<TvShowData>;
+};
+
+/**
+ * This function is ran for specific <ShowCard /> data with a TV Show ID.
+ * @returns {Promise<MovieDetailsData>} | Specific data for a TV Show that is not originally supplied by getMoviesByName.
+ */
+const getShowDetails = async (id: number): Promise<ShowData> => {
+    const response = await fetch(
+        `https://api.themoviedb.org/3/tv/${id}?api_key=${
+            import.meta.env.VITE_MOVIEDB_KEY
+        }&append_to_response=images,release_dates,content_ratings`
+    );
+    const returnRating = async (arr: TvShowDetailsData) => {
+        for (let i = 0; i < arr.content_ratings.results.length; i++) {
+            if (arr.content_ratings.results[i].iso_3166_1 === 'US') {
+                return arr.content_ratings.results[i].rating;
+            }
+        }
+        return null;
+    };
+    const data = (await response.json()) as TvShowDetailsData;
+    const obj: ShowData = {
+        id: data.id,
+        poster_path: data.poster_path,
+        title: data.original_name,
+        release_date: data.first_air_date,
+        runtime: data.episode_run_time,
+        vote_average: data.vote_average,
+        vote_count: data.vote_count,
+        age_rating: await returnRating(data),
+        overview: data.overview,
+        networks: data.networks,
+    };
+    return obj;
+};
+
+export { getShowsByName, getShowDetails };

--- a/src/helpers/getShowUtils.ts
+++ b/src/helpers/getShowUtils.ts
@@ -1,10 +1,10 @@
-import { ShowData, TvShowDetailsData, TvShowData } from '../types/tmdb';
+import { ShowData, TvShowDetailsData, TvShowData, ShowProviders } from '../types/tmdb';
 
 /**
  * This function is ran after the user enters a name of a TV Show.
- * @returns {Promise<MovieData>} | List of shows by searched query.
+ * @returns {Promise<TvShowData>} | List of shows by searched query.
  */
-const getShowsByName = async (name: string): Promise<TvShowData> => {
+const getTvByName = async (name: string): Promise<TvShowData> => {
     const response = await fetch(
         `https://api.themoviedb.org/3/search/tv?api_key=${
             import.meta.env.VITE_MOVIEDB_KEY
@@ -15,24 +15,24 @@ const getShowsByName = async (name: string): Promise<TvShowData> => {
 
 /**
  * This function is ran for specific <ShowCard /> data with a TV Show ID.
- * @returns {Promise<MovieDetailsData>} | Specific data for a TV Show that is not originally supplied by getMoviesByName.
+ * @returns {Promise<ShowData>} | Specific data for a TV Show that is not originally supplied by getMoviesByName.
  */
-const getShowDetails = async (id: number): Promise<ShowData> => {
+const getTvDetails = async (id: number): Promise<ShowData> => {
     const response = await fetch(
         `https://api.themoviedb.org/3/tv/${id}?api_key=${
             import.meta.env.VITE_MOVIEDB_KEY
         }&append_to_response=images,release_dates,content_ratings`
     );
-    const returnRating = async (arr: TvShowDetailsData) => {
+    const returnRating = (arr: TvShowDetailsData) => {
         for (let i = 0; i < arr.content_ratings.results.length; i++) {
             if (arr.content_ratings.results[i].iso_3166_1 === 'US') {
                 return arr.content_ratings.results[i].rating;
             }
         }
-        return null;
+        return 'No rating available';
     };
     const data = (await response.json()) as TvShowDetailsData;
-    const obj: ShowData = {
+    return {
         id: data.id,
         poster_path: data.poster_path,
         title: data.original_name,
@@ -40,11 +40,23 @@ const getShowDetails = async (id: number): Promise<ShowData> => {
         runtime: data.episode_run_time,
         vote_average: data.vote_average,
         vote_count: data.vote_count,
-        age_rating: await returnRating(data),
+        age_rating: returnRating(data),
         overview: data.overview,
         networks: data.networks,
-    };
-    return obj;
+    } as ShowData;
 };
 
-export { getShowsByName, getShowDetails };
+/**
+ * This function is ran for a specified movie to return streaming services with a TV Show ID.
+ * @returns {Promise<ShowProviders>} | Returns list of streaming services
+ */
+const getTvProviders = async (id: number): Promise<ShowProviders> => {
+    const response = await fetch(
+        `https://api.themoviedb.org/3/tv/${id}/watch/providers?api_key=${
+            import.meta.env.VITE_MOVIEDB_KEY
+        }`
+    );
+    return response.json() as Promise<ShowProviders>;
+};
+
+export { getTvByName, getTvDetails, getTvProviders };

--- a/src/screens/DiscoverScreen.tsx
+++ b/src/screens/DiscoverScreen.tsx
@@ -1,13 +1,13 @@
 import { useState, useEffect } from 'react';
 import { getTrending, getMovieDetails } from '../helpers/getMovieUtils';
-import { MovieDetailsData, MovieData } from '../types/tmdb';
+import { MovieData, ShowData } from '../types/tmdb';
 import { ShowCard } from '../components';
 /**
  * Requests trending movies, passing data to ShowCard components.
  * @returns {JSX.Element}
  */
 export default function DiscoverScreen(): JSX.Element {
-    const [trending, setTrending] = useState<MovieDetailsData[]>([]);
+    const [trending, setTrending] = useState<ShowData[]>([]);
     const [loading, setLoading] = useState<boolean>(true);
     useEffect(() => {
         const handler = async () => {

--- a/src/screens/SearchResultsScreen.tsx
+++ b/src/screens/SearchResultsScreen.tsx
@@ -1,8 +1,9 @@
 import { useLoaderData } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { getMoviesByName, getMovieDetails } from '../helpers/getMovieUtils';
-import { ShowCard } from '../components';
-import { MovieData, MovieDetailsData } from '../types/tmdb';
+import { ShowCard, ShowCarousel } from '../components';
+import { MovieData, ShowData, TvShowData } from '../types/tmdb';
+import { getShowsByName, getShowDetails } from '../helpers/getShowUtils';
 
 /**
  * This loader is mostly built straight from the react-router docs
@@ -26,19 +27,28 @@ export async function loader({ request }: { request: Request }): Promise<string>
  */
 export default function SearchResultsScreen(): JSX.Element {
     const query: string = useLoaderData() as string;
-    const [movieDetails, setMovieDetails] = useState<MovieDetailsData[]>([]);
+    const [movieDetails, setMovieDetails] = useState<ShowData[]>([]);
+    const [showDetails, setShowDetails] = useState<ShowData[]>([]);
     const [loading, setLoading] = useState<boolean>(true);
 
     useEffect(() => {
         // Build array of show details, set to state once complete
         const handler = async () => {
             const movieData: MovieData = await getMoviesByName(query);
+            const showData: TvShowData = await getShowsByName(query);
             const movieArr = [];
+            const showArr = [];
             for (let i = 0; i < movieData.results.length; i++) {
                 const movie = await getMovieDetails(movieData.results[i].id);
                 movieArr.push(movie);
             }
+            for (let i = 0; i < showData.results.length; i++) {
+                const show = await getShowDetails(showData.results[i].id);
+                showArr.push(show);
+                console.log(show);
+            }
             setMovieDetails(movieArr);
+            setShowDetails(showArr);
             setLoading(false);
         };
         handler();
@@ -51,9 +61,9 @@ export default function SearchResultsScreen(): JSX.Element {
         <>
             <h1 data-testid='search-results-heading'>Search Results Page</h1>
             <p>Query: {query}</p>
-            <div className='flex flex-wrap justify-center'>
-                {movieDetails.map((item, i) => item && <ShowCard key={i} details={item} />)}
-            </div>
+            {movieDetails.map((item, i) => item && <ShowCard key={i} details={item} />)}
+            {showDetails.map((item, i) => item && <ShowCard key={i} details={item} />)}
+            <ShowCarousel />
         </>
     );
 }

--- a/src/screens/SearchResultsScreen.tsx
+++ b/src/screens/SearchResultsScreen.tsx
@@ -1,9 +1,9 @@
 import { useLoaderData } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { getMoviesByName, getMovieDetails } from '../helpers/getMovieUtils';
-import { ShowCard, ShowCarousel } from '../components';
+import { ShowCard } from '../components';
 import { MovieData, ShowData, TvShowData } from '../types/tmdb';
-import { getShowsByName, getShowDetails } from '../helpers/getShowUtils';
+import { getTvByName, getTvDetails } from '../helpers/getShowUtils';
 
 /**
  * This loader is mostly built straight from the react-router docs
@@ -35,18 +35,15 @@ export default function SearchResultsScreen(): JSX.Element {
         // Build array of show details, set to state once complete
         const handler = async () => {
             const movieData: MovieData = await getMoviesByName(query);
-            const showData: TvShowData = await getShowsByName(query);
-            console.log(showData);
+            const showData: TvShowData = await getTvByName(query);
             const movieArr = [];
             const showArr = [];
             for (let i = 0; i < movieData.results.length; i++) {
                 const movie = await getMovieDetails(movieData.results[i].id);
-                console.log(movie);
                 movieArr.push(movie);
             }
             for (let i = 0; i < showData.results.length; i++) {
-                const show = await getShowDetails(showData.results[i].id);
-                console.log(show);
+                const show = await getTvDetails(showData.results[i].id);
                 showArr.push(show);
             }
             setMovieDetails(movieArr);
@@ -56,8 +53,6 @@ export default function SearchResultsScreen(): JSX.Element {
         handler();
     }, [query]);
 
-    // console.log(movieDetails)
-
     // TODO: #194 Make skeleton loading screen
     if (loading) return <p data-testid='search-results-loader'>Loading...</p>;
 
@@ -65,9 +60,10 @@ export default function SearchResultsScreen(): JSX.Element {
         <>
             <h1 data-testid='search-results-heading'>Search Results Page</h1>
             <p>Query: {query}</p>
-            {movieDetails.map((item, i) => item && <ShowCard key={i} details={item} />)}
-            {showDetails.map((item, i) => item && <ShowCard key={i} details={item} />)}
-            <ShowCarousel />
+            <div className='flex flex-wrap justify-center'>
+                {movieDetails.map((item, i) => item && <ShowCard key={i} details={item} />)}
+                {showDetails.map((item, i) => item && <ShowCard key={i} details={item} />)}
+            </div>
         </>
     );
 }

--- a/src/screens/SearchResultsScreen.tsx
+++ b/src/screens/SearchResultsScreen.tsx
@@ -36,16 +36,18 @@ export default function SearchResultsScreen(): JSX.Element {
         const handler = async () => {
             const movieData: MovieData = await getMoviesByName(query);
             const showData: TvShowData = await getShowsByName(query);
+            console.log(showData);
             const movieArr = [];
             const showArr = [];
             for (let i = 0; i < movieData.results.length; i++) {
                 const movie = await getMovieDetails(movieData.results[i].id);
+                console.log(movie);
                 movieArr.push(movie);
             }
             for (let i = 0; i < showData.results.length; i++) {
                 const show = await getShowDetails(showData.results[i].id);
-                showArr.push(show);
                 console.log(show);
+                showArr.push(show);
             }
             setMovieDetails(movieArr);
             setShowDetails(showArr);
@@ -53,6 +55,8 @@ export default function SearchResultsScreen(): JSX.Element {
         };
         handler();
     }, [query]);
+
+    // console.log(movieDetails)
 
     // TODO: #194 Make skeleton loading screen
     if (loading) return <p data-testid='search-results-loader'>Loading...</p>;

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Location, useLocation } from 'react-router-dom';
 import { getMovieDetails } from '../helpers/getMovieUtils';
-import { MovieDetailsData } from '../types/tmdb';
+import { ShowData } from '../types/tmdb';
 import { formatReleaseDate, DateSize } from '../helpers/dateFormatUtils';
 import Providers from '../components/Providers';
 
@@ -13,9 +13,11 @@ import Providers from '../components/Providers';
  */
 export default function ShowDetailsScreen(): JSX.Element {
     const location: Location = useLocation();
-    const [details, setDetails] = useState<MovieDetailsData>(
+    const [details, setDetails] = useState<ShowData>(
         location.state ? location.state.details : null
     );
+
+    console.log(location);
 
     useEffect(() => {
         const handler = async () => {
@@ -29,15 +31,7 @@ export default function ShowDetailsScreen(): JSX.Element {
         handler();
     }, []);
 
-    // TODO: #158 Possibly create utility function
-    const ratingHandler = (arr: MovieDetailsData): JSX.Element | null => {
-        for (let i = 0; i < arr.release_dates.results.length; i++) {
-            if (arr.release_dates.results[i].iso_3166_1 === 'US') {
-                return <p>{arr.release_dates.results[i].release_dates[0].certification}</p>;
-            }
-        }
-        return null;
-    };
+    console.log(details);
 
     // TODO: #199 Create skeleton loader
     if (!details) return <p>Loading</p>;
@@ -60,12 +54,21 @@ export default function ShowDetailsScreen(): JSX.Element {
                             </span>
                         )}
                         <span> {details.runtime} minutes</span>
-                        {ratingHandler(details)}
+                        <span> {details.age_rating} </span>
                     </div>
                     <div>
                         <p className='max-w-md'>{details.overview}</p>
                     </div>
-                    <Providers id={details.id} />
+                    <div>
+                        {/* {details.networks !== undefined ? (
+                            details.networks.map((item, i) => (
+                                <span></span>
+                            ))
+                        ) : (
+                            <Providers id={details.id} />
+                        )} */}
+                        <Providers id={details.id} />
+                    </div>
                     {/* TODO: #152 Include number of stars with styling, response returns rating out of 10  */}
                     <div>
                         {details.vote_average} stars out of {details.vote_count}

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -17,8 +17,6 @@ export default function ShowDetailsScreen(): JSX.Element {
         location.state ? location.state.details : null
     );
 
-    console.log(location);
-
     useEffect(() => {
         const handler = async () => {
             if (!details) {
@@ -30,8 +28,6 @@ export default function ShowDetailsScreen(): JSX.Element {
         };
         handler();
     }, []);
-
-    console.log(details);
 
     // TODO: #199 Create skeleton loader
     if (!details) return <p>Loading</p>;
@@ -59,16 +55,7 @@ export default function ShowDetailsScreen(): JSX.Element {
                     <div>
                         <p className='max-w-md'>{details.overview}</p>
                     </div>
-                    <div>
-                        {/* {details.networks !== undefined ? (
-                            details.networks.map((item, i) => (
-                                <span></span>
-                            ))
-                        ) : (
-                            <Providers id={details.id} />
-                        )} */}
-                        <Providers id={details.id} />
-                    </div>
+                    <Providers details={details} />
                     {/* TODO: #152 Include number of stars with styling, response returns rating out of 10  */}
                     <div>
                         {details.vote_average} stars out of {details.vote_count}

--- a/src/types/tmdb.ts
+++ b/src/types/tmdb.ts
@@ -14,19 +14,6 @@ interface MovieSpokenLanguages {
     name: string;
 }
 
-interface MovieReleaseDateResults {
-    iso_3166_1: string;
-    release_dates: MovieReleaseDates[];
-}
-
-interface MovieReleaseDates {
-    certification: string;
-    iso_639_1: string | null;
-    note: string;
-    release_date: string;
-    type: number;
-}
-
 interface BasicData {
     id: number;
     name: string;
@@ -48,7 +35,7 @@ export interface MovieResultData {
     original_title: string;
     overview: string;
     popularity: number;
-    poster_path: string | null;
+    poster_path: string;
     release_date: string;
     title: string;
     video: boolean;
@@ -57,6 +44,10 @@ export interface MovieResultData {
 }
 
 export interface MovieDetailsData extends MovieResultData {
+    title: string;
+    episode_run_time: number;
+    first_air_date: string;
+    original_name: string;
     belongs_to_collection: {
         backdrop_path: string;
         id: number;
@@ -89,6 +80,9 @@ export interface MovieDetailsData extends MovieResultData {
     release_dates: {
         results: MovieReleaseDateResults[];
     };
+    content_ratings?: {
+        results: MovieReleaseDateResults[];
+    };
     revenue: number;
     runtime: number;
     spoken_languages: MovieSpokenLanguages[];
@@ -96,11 +90,17 @@ export interface MovieDetailsData extends MovieResultData {
     tagline: string;
 }
 
-interface ProviderInfo {
-    display_priority?: number;
-    logo_path?: string;
-    provider_id?: number;
-    provider_name?: string;
+interface MovieReleaseDateResults {
+    iso_3166_1: string;
+    release_dates: MovieReleaseDates[];
+}
+
+interface MovieReleaseDates {
+    certification: string;
+    iso_639_1: string;
+    note: string;
+    release_date: string;
+    type: number;
 }
 
 interface ProviderDetails {
@@ -108,6 +108,13 @@ interface ProviderDetails {
     flatrate?: ProviderInfo[];
     rent?: ProviderInfo[];
     buy?: ProviderInfo[];
+}
+
+interface ProviderInfo {
+    display_priority?: number;
+    logo_path?: string;
+    provider_id?: number;
+    provider_name?: string;
 }
 
 export interface MovieProviders {
@@ -160,4 +167,144 @@ export interface MovieProviders {
         VE?: ProviderDetails;
         ZA?: ProviderDetails;
     };
+}
+
+export interface TvShowData {
+    page: number;
+    results: TvShowDetailsData[];
+    total_pages: number;
+    total_results: number;
+}
+
+export interface TvShowDetailsData {
+    backdrop_path: string | null;
+    created_by: [
+        {
+            id: number;
+            credit_id: string;
+            name: string;
+            gender: number;
+            profile_path: string | null;
+        }
+    ];
+    episode_run_time: number[];
+    first_air_date: string;
+    genres: [
+        {
+            id: number;
+            name: string;
+        }
+    ];
+    homepage: string;
+    id: number;
+    in_production: boolean;
+    languages: string[];
+    last_air_date: string;
+    last_episode_to_air: {
+        air_date: string;
+        episode_number: number;
+        id: number;
+        name: string;
+        overview: string;
+        production_code: string;
+        season_number: number;
+        still_path: string | null;
+        vote_average: number;
+        vote_count: number;
+    };
+    name: string;
+    next_episode_to_air: null;
+    networks: [
+        {
+            name: string;
+            id: number;
+            logo_path: string | null;
+            origin_country: string;
+        }
+    ];
+    number_of_episodes: number;
+    number_of_seasons: number;
+    origin_country: string[];
+    original_language: string;
+    original_name: string;
+    overview: string;
+    popularity: number;
+    poster_path: string | null;
+    production_companies: [
+        {
+            id: number;
+            logo_path: null | string;
+            name: string;
+            origin_country: string;
+        }
+    ];
+    production_countires: [
+        {
+            iso_3166_1: string;
+            name: string;
+        }
+    ];
+    seasons: [
+        {
+            air_date: string;
+            episode_count: number;
+            id: number;
+            name: string;
+            overview: string;
+            poster_path: string;
+            season_number: number;
+        }
+    ];
+    spoken_languages: [
+        {
+            english_name: string;
+            iso_639_1: string;
+            name: string;
+        }
+    ];
+    status: string;
+    tagline: string;
+    type: string;
+    vote_average: number;
+    vote_count: number;
+    // content_ratings append to response
+    content_ratings: {
+        id: number;
+        results: [
+            {
+                iso_3166_1: string;
+                rating: string;
+            }
+        ];
+    };
+    release_dates: TvShowReleaseDates;
+}
+
+interface TvShowReleaseDates {
+    results: [
+        {
+            iso_3166_1: string;
+            rating: string;
+        }
+    ];
+}
+
+export interface ShowData {
+    id: number;
+    overview: string;
+    poster_path: string | null;
+    release_date: string;
+    age_rating?: string | null;
+    runtime: number | number[];
+    title: string;
+    vote_average: number;
+    vote_count: number;
+    networks?: [
+        {
+            name: string;
+            id: number;
+            logo_path: string | null;
+            origin_country: string;
+        }
+    ];
 }

--- a/src/types/tmdb.ts
+++ b/src/types/tmdb.ts
@@ -35,7 +35,7 @@ export interface MovieResultData {
     original_title: string;
     overview: string;
     popularity: number;
-    poster_path: string;
+    poster_path: string | null;
     release_date: string;
     title: string;
     video: boolean;
@@ -44,10 +44,6 @@ export interface MovieResultData {
 }
 
 export interface MovieDetailsData extends MovieResultData {
-    title: string;
-    episode_run_time: number;
-    first_air_date: string;
-    original_name: string;
     belongs_to_collection: {
         backdrop_path: string;
         id: number;
@@ -80,19 +76,11 @@ export interface MovieDetailsData extends MovieResultData {
     release_dates: {
         results: MovieReleaseDateResults[];
     };
-    content_ratings?: {
-        results: MovieReleaseDateResults[];
-    };
     revenue: number;
     runtime: number;
     spoken_languages: MovieSpokenLanguages[];
     status: string;
     tagline: string;
-}
-
-interface MovieReleaseDateResults {
-    iso_3166_1: string;
-    release_dates: MovieReleaseDates[];
 }
 
 interface MovieReleaseDates {
@@ -101,6 +89,11 @@ interface MovieReleaseDates {
     note: string;
     release_date: string;
     type: number;
+}
+
+interface MovieReleaseDateResults {
+    iso_3166_1: string;
+    release_dates: MovieReleaseDates[];
 }
 
 interface ProviderDetails {
@@ -117,7 +110,7 @@ interface ProviderInfo {
     provider_name?: string;
 }
 
-export interface MovieProviders {
+export interface ShowProviders {
     id: number;
     results: {
         AR?: ProviderDetails;


### PR DESCRIPTION
- Created TV Show Request to return TV Shows by a searched query. This data is then passed into a TV Show details request which is identical to how our Movies behave. Closes #227
- Refactored Movie requests to return a custom object with the relevant data we need. This provides a universal object for both Movies and TV Shows, resulting in fewer conditionals across the different types of requests we are using. Closes #234 
- Created TV Show Providers request. Identical to Movies, an ID is passed through to our `Providers` component, invoking the function and returning a list of streaming servcies. Closes #242 

- Misc Type changes. Created interface `ShowData` that operates as our custom return object types. 

This concludes, and Closes #226 

Due to user error, commit history is slightly off. However, each commit is supposed to represent each ticket closed, excluding the parent ticket #226. If you have any questions regarding this, let me know!

Lastly, created ticket #243