### PR TITLE
Convert show details screen to allow Movie or TV show

### DIFF
--- a/src/__tests__/routes.tsx
+++ b/src/__tests__/routes.tsx
@@ -52,7 +52,7 @@ export const routes: RouteObject[] = [
                 loader: searchLoader,
             },
             {
-                path: 'details/:id',
+                path: 'details/movie/:id',
                 element: <ShowDetailsScreen />,
             },
         ],
@@ -70,7 +70,7 @@ export const showCardRoutes: RouteObject[] = [
         children: [
             {
                 path: '/',
-                element: <ShowCard details={sampleMovieData as ShowData} />,
+                element: <ShowCard details={sampleMovieData as ShowData} showType={'movie'} />,
             },
         ],
     },

--- a/src/__tests__/screens/movieScreen.test.tsx
+++ b/src/__tests__/screens/movieScreen.test.tsx
@@ -90,6 +90,6 @@ describe('Movie Screen Test Suite', async () => {
         expect(image).toBeInTheDocument();
         expect(image.src).toBe('https://image.tmdb.org/t/p/w500/7rwgEs15tFwyR9NPQ5vpzxTj19Q.jpg');
         expect(screen.getByTestId('details-release-date')).toBeInTheDocument();
-        expect(screen.getByTestId('details-release-date')).toHaveTextContent('May 7th, 2010');
+        expect(screen.getByTestId('details-release-date')).toHaveTextContent('April 30th, 2008');
     });
 });

--- a/src/components/ShowCard.tsx
+++ b/src/components/ShowCard.tsx
@@ -13,6 +13,7 @@ import { Box } from '@mui/system';
 
 interface MovieCardProps {
     details: ShowData;
+    showType: string;
 }
 
 /**
@@ -23,7 +24,7 @@ interface MovieCardProps {
  * @param props | returns details object passed from SearchResultScreen.tsx
  * @returns {JSX.Element} | Single show card
  */
-export default function ShowCard({ details }: MovieCardProps): JSX.Element {
+export default function ShowCard({ details, showType }: MovieCardProps): JSX.Element {
     const { profile, setProfile } = useProfileContext();
     const [isInWatchQueue, setIsInWatchQueue] = useState<boolean>(false);
 
@@ -64,7 +65,11 @@ export default function ShowCard({ details }: MovieCardProps): JSX.Element {
 
     return (
         <div data-testid='show-card-component' className='m-1 flex w-96 bg-foreground'>
-            <Link to={`/details/${details.id}`} state={details} data-testid='show-details-link'>
+            <Link
+                to={`/details/${showType}/${details.id}`}
+                state={details}
+                data-testid='show-details-link'
+            >
                 {/* TODO: #193 Add placeholder poster if null */}
                 {details.poster_path && (
                     <CardMedia

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -53,7 +53,11 @@ const router = createBrowserRouter([
                 loader: searchLoader,
             },
             {
-                path: 'details/:id',
+                path: 'details/movie/:id',
+                element: <ShowDetailsScreen />,
+            },
+            {
+                path: 'details/tv/:id',
                 element: <ShowDetailsScreen />,
             },
             {

--- a/src/screens/DiscoverScreen.tsx
+++ b/src/screens/DiscoverScreen.tsx
@@ -28,5 +28,12 @@ export default function DiscoverScreen(): JSX.Element {
     // TODO: #194 Make skeleton loading screen
     if (loading) return <p>Loading...</p>;
 
-    return <div>{trending.map((item, i) => item && <ShowCard key={i} details={item} />)}</div>;
+    return (
+        <div>
+            {trending.map(
+                // TODO: make showType dynamic
+                (item, i) => item && <ShowCard key={i} details={item} showType='movie' />
+            )}
+        </div>
+    );
 }

--- a/src/screens/SearchResultsScreen.tsx
+++ b/src/screens/SearchResultsScreen.tsx
@@ -50,8 +50,12 @@ export default function SearchResultsScreen(): JSX.Element {
             <h1 data-testid='search-results-heading'>Search Results Page</h1>
             <p>Query: {query}</p>
             <div className='flex flex-wrap justify-center'>
-                {movieDetails?.map((item, i) => item && <ShowCard key={i} details={item} />)}
-                {tvDetails?.map((item, i) => item && <ShowCard key={i} details={item} />)}
+                {movieDetails?.map(
+                    (item, i) => item && <ShowCard key={i} details={item} showType={'movie'} />
+                )}
+                {tvDetails?.map(
+                    (item, i) => item && <ShowCard key={i} details={item} showType={'tv'} />
+                )}
             </div>
         </>
     );

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -4,6 +4,7 @@ import { getMovieDetails, getMovieRecommendations } from '../helpers/getMovieUti
 import { ShowData } from '../types';
 import { formatReleaseDate, DateSize } from '../helpers/dateFormatUtils';
 import { Providers, ShowCard } from '../components';
+import { getTvDetails, getTvRecommendations } from '../helpers/getTvUtils';
 
 /**
  * Screen to show more details of a specific show
@@ -17,14 +18,22 @@ export default function ShowDetailsScreen(): JSX.Element {
         location.state ? location.state.details : null
     );
     const [recommendations, setRecommendation] = useState<ShowData[] | null>(null);
-    const id = parseInt(location.pathname.split('/')[2]);
+    const id = parseInt(location.pathname.split('/')[3]);
+    const showType = location.pathname.split('/')[2];
 
     useEffect(() => {
         const handler = async () => {
-            const movieDetails = await getMovieDetails(id);
-            setDetails(movieDetails);
-            const recommendation = await getMovieRecommendations(id);
-            if (recommendation) setRecommendation(recommendation);
+            if (showType === 'movie') {
+                const movieDetails = await getMovieDetails(id);
+                setDetails(movieDetails);
+                const recommendation = await getMovieRecommendations(id);
+                if (recommendation) setRecommendation(recommendation);
+            } else {
+                const tvDetails = await getTvDetails(id);
+                setDetails(tvDetails);
+                const recommendation = await getTvRecommendations(id);
+                if (recommendation) setRecommendation(recommendation);
+            }
         };
         handler();
     }, [location]);
@@ -64,7 +73,9 @@ export default function ShowDetailsScreen(): JSX.Element {
             </section>
             <section className='flex flex-wrap justify-center'>
                 {recommendations &&
-                    recommendations.map((item, i) => item && <ShowCard key={i} details={item} />)}
+                    recommendations.map(
+                        (item, i) => item && <ShowCard key={i} details={item} showType={showType} />
+                    )}
             </section>
         </>
     );


### PR DESCRIPTION
Refactor show details screen to allow for movie or tv show. Created a show type prop to be passed to the show card. This then sets the appropriate URL for the details screen. Finally, we can pull the show type out of the URL on the details page to make the appropriate queries.

- #274 