### PR TITLE
Rating converted to component

### DIFF
--- a/src/components/Rating.tsx
+++ b/src/components/Rating.tsx
@@ -1,0 +1,38 @@
+import { Rating as RatingMUI, Typography } from '@mui/material';
+import { pluralizeString } from '../helpers/stringFormatUtils';
+
+interface RatingProps {
+    /**
+     * Average rating out of 10 based on all
+     * TMDB user ratings
+     */
+    vote_average: number;
+    /**
+     * Total number of people who rated the show
+     */
+    vote_count: number;
+}
+
+/**
+ * Shows 5 stars which are filled, half-filled, or empty
+ * based on the `vote_average`
+ * Text below stars reads '`vote_count` rating(s)'
+ *
+ * @param props | vote count and average rating
+ * @returns {JSX.Element} | Stars with text below
+ */
+export default function Rating({ vote_average, vote_count }: RatingProps): JSX.Element {
+    return (
+        <div className='flex flex-col my-2'>
+            <RatingMUI
+                name='half-rating'
+                defaultValue={vote_average / 2}
+                precision={0.5}
+                readOnly
+            />
+            <Typography variant='body2' align='left' paddingLeft={0.6}>
+                {vote_count} {pluralizeString(vote_count, 'rating')}
+            </Typography>
+        </div>
+    );
+}

--- a/src/components/ShowCard.tsx
+++ b/src/components/ShowCard.tsx
@@ -2,9 +2,9 @@ import { addToProfileWatchQueue, removeFromProfileWatchQueue } from '../supabase
 import { Profile, ShowData } from '../types';
 import { Link } from 'react-router-dom';
 import { formatReleaseDate, DateSize } from '../helpers/dateFormatUtils';
-import { Button, CardActions, CardMedia, Rating, Typography } from '@mui/material';
+import { Button, CardActions, CardMedia, Typography } from '@mui/material';
 import { Box } from '@mui/system';
-import { pluralizeString } from '../helpers/stringFormatUtils';
+import Rating from './Rating';
 
 interface ShowCardProps {
     /**
@@ -89,13 +89,13 @@ export default function ShowCard({
                     flexDirection: 'column',
                     justifyContent: 'space-between',
                     paddingY: '10px',
+                    paddingLeft: '5px',
                 }}
             >
                 <Box>
                     <Typography
                         variant='h5'
                         align='left'
-                        paddingLeft={1}
                         sx={{
                             overflow: 'hidden',
                             textOverflow: 'ellipsis',
@@ -107,28 +107,16 @@ export default function ShowCard({
                         {details.title}
                     </Typography>
                     {details.release_date && details.release_date.length === 10 && (
-                        <Typography align='left' paddingLeft={1}>
+                        <Typography align='left'>
                             {formatReleaseDate(details.release_date, DateSize.MEDIUM)}
                         </Typography>
                     )}
                 </Box>
                 <Box>
-                    <div>
-                        <Rating
-                            name='half-rating'
-                            defaultValue={details.vote_average ? details.vote_average / 2 : 0}
-                            precision={0.5}
-                            style={{ width: '100%', paddingLeft: '5px' }}
-                            readOnly
-                        />
-                        <Typography variant='body2' align='left' paddingLeft={1}>
-                            {details.vote_average && details.vote_count
-                                ? details.vote_count +
-                                  ' ' +
-                                  pluralizeString(details.vote_count, 'rating')
-                                : 'No Ratings available'}
-                        </Typography>
-                    </div>
+                    <Rating
+                        vote_average={details.vote_average || 0}
+                        vote_count={details.vote_count || 0}
+                    />
                     {profile && (
                         <CardActions
                             sx={{

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,6 +12,7 @@ import { LoginForm, SignUpForm } from './auth';
 import ErrorMessage from './ErrorMessage';
 import Providers from './Providers';
 import ProvidersPlaceholder from './ProvidersPlaceholder';
+import Rating from './Rating';
 
 export {
     ShowCard,
@@ -25,4 +26,5 @@ export {
     ErrorMessage,
     Providers,
     ProvidersPlaceholder,
+    Rating,
 };

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -5,8 +5,9 @@ import { ShowData } from '../types';
 import { formatReleaseDate, DateSize } from '../helpers/dateFormatUtils';
 import { Providers, ShowCard } from '../components';
 import { getTvDetails, getTvRecommendations } from '../helpers/getTvUtils';
-import { Rating, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { useProfileContext } from '../hooks';
+import Rating from '../components/Rating';
 
 /**
  * Screen to show more details of a specific show
@@ -71,28 +72,17 @@ export default function ShowDetailsScreen(): JSX.Element {
                                 {formatReleaseDate(details.release_date, DateSize.LONG)}
                             </Typography>
                         )}
-                        <Typography align='left'>Rated {details.age_rating} </Typography>
+                        <Typography align='left'>{details.age_rating}</Typography>
                         {details.runtime && (
                             <Typography align='left' variant='body2'>
                                 {details.runtime} minutes
                             </Typography>
                         )}
                     </div>
-                    {details.vote_average ? (
-                        <div className='flex flex-col my-2'>
-                            <Rating
-                                name='half-rating'
-                                defaultValue={details.vote_average / 2}
-                                precision={0.5}
-                                readOnly
-                            />
-                            <Typography variant='body2' align='left'>
-                                {details.vote_count} ratings
-                            </Typography>
-                        </div>
-                    ) : (
-                        <Typography variant='body2'>No ratings available</Typography>
-                    )}
+                    <Rating
+                        vote_average={details.vote_average || 0}
+                        vote_count={details.vote_count || 0}
+                    />
                     <div>
                         <Typography align='left' className='max-w-md py-3'>
                             {details.overview}

--- a/src/stories/components/Rating.stories.ts
+++ b/src/stories/components/Rating.stories.ts
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Rating } from '../../components';
+
+const meta = {
+    title: 'Components/Rating',
+    component: Rating,
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'centered',
+    },
+} satisfies Meta<typeof Rating>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+    args: {
+        vote_average: 5,
+        vote_count: 1,
+    },
+};


### PR DESCRIPTION
Using the MUI rating component, created a wrapper class that will display text below the rating and can be further customized in the future if needed. Also added to storybook.

One small change to the logic is that now when there are not ratings, instead of showing "No ratings available" we show a rating with 0 stars and the text "0 ratings".

## Screenshots

![image](https://github.com/Thenlie/Streamability/assets/41388783/8b8d48ad-5b21-46df-a7b0-94c6ef92d389)

Closes #443 