### PR TITLE
Implement lint staged script

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,9 +1,4 @@
 #!/bin/bash
-#
-# An example hook script to verify what is about to be committed.
-# Called by "git commit" with no arguments.  The hook should
-# exit with non-zero status after issuing an appropriate message if
-# it wants to stop the commit.
 
 if [ "$NO_VERIFY" ]; then
     printf "\033[41m ⚠️  pre-commit hook skipped\033[0m\n"
@@ -19,13 +14,9 @@ else
     exit 1
 fi
 
-echo "--- Running ES-Lint ---"
-npm run lint-fix
-if [[ "$?" == 0 ]]; then
-    git add -A
-    printf "\033[32m✅ ESLint Passed\033[0m\n"
-else
-    printf "\033[41m❌ ESLint Failed\033[0m\n"
+# Run es-lint script
+bash scripts/lint-staged.sh
+if [[ "$?" != 0 ]]; then
     exit 1
 fi
 

--- a/scripts/lint-staged.sh
+++ b/scripts/lint-staged.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Run es-lint on staged files with the fix flag
+
+echo "--- Running ES-Lint ---"
+passing=true
+while read filename; do
+    if [[ "$filename" =~ \.ts$ || "$filename" =~ \.tsx ]]; then
+        npx eslint $filename --fix
+        if [[ "$?" == 0 ]]; then
+            git add $filename
+            printf "\033[32m✅ ESLint Passed for $filename\033[0m\n"
+        else
+            printf "\033[41m❌ ESLint Failed for $filename\033[0m\n"
+            passing=false
+        fi
+    fi
+done < <(git diff --cached --name-only --diff-filter=ACMR )
+if [[ "$passing" == false ]] ; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
There was a bug in my previous pre-commit script where you were unable to leave files in your working directory as they would always get added with `git add -A`. We now get a list of staged files and then only run es-lint on those files. This makes the check slightly faster and allows a dev to leave un-staged files in their working directory while committing others.

Worth noting that the CI still run es-lint on every file. This will ensure the app retains a 100% es-lint pass rate with the changes mentioned above.

Closes #440 