### PR TITLE
Implement list card view on search results

### DIFF
--- a/src/AppWrapper.tsx
+++ b/src/AppWrapper.tsx
@@ -135,7 +135,7 @@ export default function AppWrapper(): JSX.Element {
             >
                 <main className='flex min-h-screen flex-col place-items-center'>
                     <Navigation session={session} switchTheme={themeSwitcher} theme={theme} />
-                    <div className='flex flex-auto flex-col items-center justify-center text-center'>
+                    <div className='flex flex-auto flex-col items-center justify-center text-center w-full'>
                         <Outlet context={{ session, setSession, profile, setProfile }} />
                     </div>
                 </main>

--- a/src/components/ShowCard.tsx
+++ b/src/components/ShowCard.tsx
@@ -6,7 +6,7 @@ import { Button, CardActions, CardMedia, Typography } from '@mui/material';
 import Rating from './Rating';
 import { useIsInWatchQueue } from '../hooks';
 
-interface ShowCardProps {
+export interface ShowCardProps {
     /**
      * Movie or TV show metadata
      */

--- a/src/components/ShowCard.tsx
+++ b/src/components/ShowCard.tsx
@@ -67,7 +67,7 @@ export default function ShowCard({
     };
 
     return (
-        <div data-testid='show-card-component' className='m-1 flex w-96 bg-foreground rounded-sm'>
+        <div data-testid='show-card-component' className='m-1 flex w-80 bg-foreground rounded-sm'>
             <Link
                 to={`/details/${showType}/${details.id}`}
                 state={details}

--- a/src/components/ShowCarousel.tsx
+++ b/src/components/ShowCarousel.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 import { useWindowSize } from '../hooks';
 import useDebounce from '../hooks/useDebounceValue';
 
-const SHOW_CARD_WIDTH = 390;
+const SHOW_CARD_WIDTH = 360;
 
 interface ShowCarouselProps {
     /**

--- a/src/components/ShowListCard.tsx
+++ b/src/components/ShowListCard.tsx
@@ -6,7 +6,7 @@ import { Button, CardActions, CardMedia, Rating, Typography } from '@mui/materia
 import { pluralizeString } from '../helpers/stringFormatUtils';
 import { useIsInWatchQueue } from '../hooks';
 
-interface ShowListCardProps {
+export interface ShowListCardProps {
     /**
      * Movie or TV show metadata
      */

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -83,7 +83,7 @@ export default function LoginForm(): JSX.Element {
     }
 
     return (
-        <div aria-live='polite' className='w-full'>
+        <div aria-live='polite'>
             <h1 data-testid='login-heading'>Login</h1>
             <form onSubmit={signInWithEmail} className='flex flex-col' data-testid='login-form'>
                 <FormControl sx={{ m: 0.5 }} variant='filled'>

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -143,7 +143,7 @@ export default function SignUpForm(): JSX.Element {
     };
 
     return (
-        <div aria-live='polite' className='w-full'>
+        <div aria-live='polite'>
             <h1 data-testid='signup-heading'>Signup</h1>
             <form onSubmit={signUpHandler} className='flex flex-col' data-testid='signup-form'>
                 <FormControl sx={{ m: 0.5 }} variant='filled'>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,8 +2,8 @@
  * This file exports all components to make imports easier
  * Be sure to add any new components to this file
  */
-import ShowCard from './ShowCard';
-import ShowListCard from './ShowListCard';
+import ShowCard, { ShowCardProps } from './ShowCard';
+import ShowListCard, { ShowListCardProps } from './ShowListCard';
 import ShowCardPlaceholder from './ShowCardPlaceholder';
 import ShowListCardPlaceholder from './ShowListCardPlaceholder';
 import ProvidersPlaceholder from './ProvidersPlaceholder';
@@ -32,3 +32,5 @@ export {
     Navigation,
     Rating,
 };
+
+export type { ShowCardProps, ShowListCardProps };

--- a/src/screens/SearchResultsScreen.tsx
+++ b/src/screens/SearchResultsScreen.tsx
@@ -1,11 +1,14 @@
 import { useLoaderData } from 'react-router-dom';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { getMoviesByName } from '../helpers/getMovieUtils';
-import { ShowCard } from '../components';
+import { ShowCard, ShowListCard } from '../components';
 import { ShowData } from '../types';
 import { getTvByName } from '../helpers/getTvUtils';
 import ShowCardPlaceholder from '../components/ShowCardPlaceholder';
-import { useProfileContext } from '../hooks';
+import { useProfileContext, useWindowSize } from '../hooks';
+import { ToggleButton } from '@mui/material';
+import { ViewList, ViewModule } from '@mui/icons-material';
+import { ShowCardProps } from '../components/ShowCard';
 
 /**
  * This loader is mostly built straight from the react-router docs
@@ -25,18 +28,29 @@ export async function loader({ request }: { request: Request }): Promise<string>
 }
 
 /**
- * @returns {JSX.Element} results page after user input
+ * The page displayed after a user makes a search query
+ *
+ * @returns {JSX.Element}
  */
 export default function SearchResultsScreen(): JSX.Element {
     const query: string = useLoaderData() as string;
     const { profile, setProfile } = useProfileContext();
+    const windowSize = useWindowSize();
+    const [viewState, setViewState] = useState<'list' | 'grid'>('list');
     const [movieDetails, setMovieDetails] = useState<ShowData[] | null>(null);
     const [tvDetails, setTvDetails] = useState<ShowData[] | null>(null);
     const [loading, setLoading] = useState<boolean>(true);
 
     useEffect(() => {
+        // default to grid view on mobile
+        if (windowSize.width && windowSize.width < 750) {
+            setViewState('grid');
+        }
+    }, [windowSize]);
+
+    useEffect(() => {
         const handler = async () => {
-            // TODO: Refactor to use multi search
+            // TODO: #478 Refactor to use multi search
             // https://developer.themoviedb.org/reference/search-multi
             const movieData: ShowData[] | null = await getMoviesByName(query);
             const tvData: ShowData[] | null = await getTvByName(query);
@@ -46,6 +60,49 @@ export default function SearchResultsScreen(): JSX.Element {
         };
         handler();
     }, [query]);
+
+    const handleViewToggle = () => {
+        setViewState((prev) => (prev === 'grid' ? 'list' : 'grid'));
+    };
+
+    /**
+     * Loops over show details and creates an array of show cards
+     * using the correct component based on the `viewState`
+     *
+     * @returns {JSX.Element}
+     */
+    const searchResultCards = useMemo((): JSX.Element => {
+        const CardComp: React.FC<ShowCardProps> = (props) => {
+            return viewState === 'grid' ? <ShowCard {...props} /> : <ShowListCard {...props} />;
+        };
+
+        return (
+            <>
+                {movieDetails?.map((item, i) => {
+                    return (
+                        <CardComp
+                            key={i}
+                            details={item}
+                            showType={'movie'}
+                            profile={profile}
+                            setProfile={setProfile}
+                        />
+                    );
+                })}
+                {tvDetails?.map((item, i) => {
+                    return (
+                        <CardComp
+                            key={i}
+                            details={item}
+                            showType={'tv'}
+                            profile={profile}
+                            setProfile={setProfile}
+                        />
+                    );
+                })}
+            </>
+        );
+    }, [movieDetails, tvDetails, viewState]);
 
     if (loading) {
         return <ShowCardPlaceholder count={5} />;
@@ -58,33 +115,23 @@ export default function SearchResultsScreen(): JSX.Element {
 
     return (
         <>
-            <h1 data-testid='search-results-heading' className='w-full text-left text-xl p-2 pl-6'>
-                Search results for: {query}
-            </h1>
-            <div className='flex flex-wrap justify-center'>
-                {movieDetails?.map((item, i) => {
-                    return (
-                        <ShowCard
-                            key={i}
-                            details={item}
-                            showType={'movie'}
-                            profile={profile}
-                            setProfile={setProfile}
-                        />
-                    );
-                })}
-                {tvDetails?.map((item, i) => {
-                    return (
-                        <ShowCard
-                            key={i}
-                            details={item}
-                            showType={'tv'}
-                            profile={profile}
-                            setProfile={setProfile}
-                        />
-                    );
-                })}
+            <div className='flex justify-between align-middle w-full p-3'>
+                <h1
+                    data-testid='search-results-heading'
+                    className='w-full text-left text-xl self-center'
+                >
+                    Search results for: {query}
+                </h1>
+                <ToggleButton
+                    sx={windowSize.width && windowSize.width < 750 ? { display: 'none' } : {}}
+                    value='toggle card view'
+                    aria-label='toggle card view'
+                    onClick={handleViewToggle}
+                >
+                    {viewState === 'grid' ? <ViewList /> : <ViewModule />}
+                </ToggleButton>
             </div>
+            <div className='flex flex-wrap justify-center pb-4'>{searchResultCards}</div>
         </>
     );
 }

--- a/src/screens/SearchResultsScreen.tsx
+++ b/src/screens/SearchResultsScreen.tsx
@@ -6,7 +6,7 @@ import { ShowData } from '../types';
 import { getTvByName } from '../helpers/getTvUtils';
 import ShowCardPlaceholder from '../components/ShowCardPlaceholder';
 import { useProfileContext, useWindowSize } from '../hooks';
-import { ToggleButton } from '@mui/material';
+import { ToggleButton, Tooltip } from '@mui/material';
 import { ViewList, ViewModule } from '@mui/icons-material';
 
 /**
@@ -127,14 +127,16 @@ export default function SearchResultsScreen(): JSX.Element {
                 >
                     Search results for: {query}
                 </h1>
-                <ToggleButton
-                    sx={windowSize.width && windowSize.width < 750 ? { display: 'none' } : {}}
-                    value='toggle card view'
-                    aria-label='toggle card view'
-                    onClick={handleViewToggle}
-                >
-                    {viewState === 'grid' ? <ViewList /> : <ViewModule />}
-                </ToggleButton>
+                <Tooltip title='toggle card view'>
+                    <ToggleButton
+                        sx={windowSize.width && windowSize.width < 750 ? { display: 'none' } : {}}
+                        value='toggle card view'
+                        aria-label='toggle card view'
+                        onClick={handleViewToggle}
+                    >
+                        {viewState === 'grid' ? <ViewList /> : <ViewModule />}
+                    </ToggleButton>
+                </Tooltip>
             </div>
             {searchResultCards}
         </>

--- a/src/screens/SearchResultsScreen.tsx
+++ b/src/screens/SearchResultsScreen.tsx
@@ -1,14 +1,13 @@
 import { useLoaderData } from 'react-router-dom';
 import { useState, useEffect, useMemo } from 'react';
 import { getMoviesByName } from '../helpers/getMovieUtils';
-import { ShowCard, ShowListCard } from '../components';
+import { ShowCard, ShowListCard, ShowCardProps, ShowListCardProps } from '../components';
 import { ShowData } from '../types';
 import { getTvByName } from '../helpers/getTvUtils';
 import ShowCardPlaceholder from '../components/ShowCardPlaceholder';
 import { useProfileContext, useWindowSize } from '../hooks';
 import { ToggleButton } from '@mui/material';
 import { ViewList, ViewModule } from '@mui/icons-material';
-import { ShowCardProps } from '../components/ShowCard';
 
 /**
  * This loader is mostly built straight from the react-router docs
@@ -72,7 +71,7 @@ export default function SearchResultsScreen(): JSX.Element {
      * @returns {JSX.Element}
      */
     const searchResultCards = useMemo((): JSX.Element => {
-        const CardComp: React.FC<ShowCardProps> = (props) => {
+        const CardComp: React.FC<ShowCardProps | ShowListCardProps> = (props) => {
             return viewState === 'grid' ? <ShowCard {...props} /> : <ShowListCard {...props} />;
         };
 

--- a/src/screens/SearchResultsScreen.tsx
+++ b/src/screens/SearchResultsScreen.tsx
@@ -76,7 +76,13 @@ export default function SearchResultsScreen(): JSX.Element {
         };
 
         return (
-            <>
+            <div
+                className={
+                    viewState === 'grid'
+                        ? 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
+                        : 'flex flex-wrap justify-center'
+                }
+            >
                 {movieDetails?.map((item, i) => {
                     return (
                         <CardComp
@@ -99,7 +105,7 @@ export default function SearchResultsScreen(): JSX.Element {
                         />
                     );
                 })}
-            </>
+            </div>
         );
     }, [movieDetails, tvDetails, viewState]);
 
@@ -130,7 +136,7 @@ export default function SearchResultsScreen(): JSX.Element {
                     {viewState === 'grid' ? <ViewList /> : <ViewModule />}
                 </ToggleButton>
             </div>
-            <div className='flex flex-wrap justify-center pb-4'>{searchResultCards}</div>
+            {searchResultCards}
         </>
     );
 }

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -43,12 +43,12 @@ export default function ShowDetailsScreen(): JSX.Element {
     }, [location]);
 
     // TODO: #199 Create skeleton loader
-    // TODO: Handle case when no details are ever returned
+    // TODO: #438 Handle case when no details are ever returned
     if (!details) return <p>Loading</p>;
 
     return (
         <>
-            <section className='m-3 flex'>
+            <section className='m-12 flex'>
                 <div className='rounded-md overflow-hidden mr-2'>
                     {details.poster_path ? (
                         <img
@@ -64,7 +64,12 @@ export default function ShowDetailsScreen(): JSX.Element {
                 </div>
                 <div className='m-3'>
                     <div>
-                        <Typography variant='h3' align='left' data-testid='show-details-heading'>
+                        <Typography
+                            variant='h3'
+                            align='left'
+                            className='max-w-lg'
+                            data-testid='show-details-heading'
+                        >
                             {details.title}
                         </Typography>
                         {details.release_date && details.release_date.length === 10 && (
@@ -84,7 +89,7 @@ export default function ShowDetailsScreen(): JSX.Element {
                         vote_count={details.vote_count || 0}
                     />
                     <div>
-                        <Typography align='left' className='max-w-md py-3'>
+                        <Typography align='left' className='max-w-lg py-3'>
                             {details.overview}
                         </Typography>
                     </div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -17,6 +17,13 @@ module.exports = {
                 sans: ['Inter', 'Avenir', 'Helvetica', ...defaultTheme.fontFamily.sans],
             },
         },
+        screens: {
+            'sm': '640px',
+            'md': '768px',
+            'lg': '1024px',
+            'xl': '1350px',
+            '2xl': '1536px',
+        }
     },
     plugins: [],
 };


### PR DESCRIPTION
The default view on tablet and desktop will now be the list view. On mobile, grid view will be the default. 

The toggle will swap between views. Since the list card does not work on mobile views, the toggle is hidden on those devices. 

## Screenshots

![image](https://github.com/Thenlie/Streamability/assets/41388783/8945eed6-f09a-4a07-99ca-e3671568f3a8)
![image](https://github.com/Thenlie/Streamability/assets/41388783/2039fa7e-b67d-4a8c-8b77-161e9786777f)

Closes #436 
