### PR TITLE
Refactor loading components

### DIFF
--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { ShowProviders } from '../types';
 import { getMovieProviders, getTvProviders } from '../helpers';
-import ProvidersPlaceholder from './ProvidersPlaceholder';
+import { ProvidersLoader } from './loaders';
 import { useWindowSize } from '../hooks';
 import useDebounceValue from '../hooks/useDebounceValue';
 
@@ -50,7 +50,7 @@ export default function Providers({ id, showType }: ProviderProps): JSX.Element 
     if (loading) {
         return (
             <div className='flex justify-center'>
-                <ProvidersPlaceholder count={3} />
+                <ProvidersLoader count={3} />
             </div>
         );
     }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,11 +4,7 @@
  */
 import ShowCard, { ShowCardProps } from './ShowCard';
 import ShowListCard, { ShowListCardProps } from './ShowListCard';
-import ShowCardPlaceholder from './ShowCardPlaceholder';
-import ShowListCardPlaceholder from './ShowListCardPlaceholder';
 import ShowPoster from './ShowPoster';
-import ProvidersPlaceholder from './ProvidersPlaceholder';
-import ShowCarouselPlaceholder from './ShowCarouselPlaceholder';
 import ShowCarousel from './ShowCarousel';
 import SearchInput from './SearchInput';
 import { LoginForm, SignUpForm } from './auth';
@@ -20,11 +16,7 @@ import Rating from './Rating';
 export {
     ShowCard,
     ShowListCard,
-    ShowCardPlaceholder,
-    ShowListCardPlaceholder,
     ShowPoster,
-    ProvidersPlaceholder,
-    ShowCarouselPlaceholder,
     ShowCarousel,
     SearchInput,
     LoginForm,
@@ -34,5 +26,5 @@ export {
     Navigation,
     Rating,
 };
-
+export * from './loaders';
 export type { ShowCardProps, ShowListCardProps };

--- a/src/components/loaders/ProvidersLoader.tsx
+++ b/src/components/loaders/ProvidersLoader.tsx
@@ -1,7 +1,7 @@
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
 
-interface ProvidersPlaceholderProps {
+interface ProvidersLoaderProps {
     /**
      * Number of skeleton loaders to display
      */
@@ -14,7 +14,7 @@ interface ProvidersPlaceholderProps {
  * @param count | number placeholders to be rendered
  * @returns {JSX.Element}
  */
-export default function ProvidersPlaceholder({ count }: ProvidersPlaceholderProps): JSX.Element {
+export default function ProvidersLoader({ count }: ProvidersLoaderProps): JSX.Element {
     return (
         <div className='m-3 flex flex-wrap justify-center bg-primary rounded-sm p-1'>
             {[...Array(count)].map((x, i) => (

--- a/src/components/loaders/ShowCardLoader.tsx
+++ b/src/components/loaders/ShowCardLoader.tsx
@@ -1,7 +1,7 @@
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
 
-interface ShowCardPlaceholderProps {
+interface ShowCardLoaderProps {
     /**
      * Number of skeleton loaders to display
      */
@@ -14,7 +14,7 @@ interface ShowCardPlaceholderProps {
  * @param count | number of card placeholders to be rendered
  * @returns {JSX.Element}
  */
-export default function ShowCardPlaceholder({ count }: ShowCardPlaceholderProps): JSX.Element {
+export default function ShowCardLoader({ count }: ShowCardLoaderProps): JSX.Element {
     return (
         <>
             {[...Array(count)].map((x, i) => (

--- a/src/components/loaders/ShowCarouselLoader.tsx
+++ b/src/components/loaders/ShowCarouselLoader.tsx
@@ -1,6 +1,6 @@
-import ShowCardPlaceholder from './ShowCardPlaceholder';
+import ShowCardLoader from './ShowCardLoader';
 
-interface ShowCarouselPlaceholderProps {
+interface ShowCarouselLoaderProps {
     /**
      * Number of skeleton loaders to display
      */
@@ -10,17 +10,15 @@ interface ShowCarouselPlaceholderProps {
 /**
  * A skeleton loader of the ShowCarousel component. To be rendered while
  * main component is loading.
- * @param count | number of card placeholders to be rendered
+ * @param count | number of card loaders to be rendered
  * @returns {JSX.Element}
  */
-export default function ShowCarouselPlaceholder({
-    count,
-}: ShowCarouselPlaceholderProps): JSX.Element {
+export default function ShowCarouselLoader({ count }: ShowCarouselLoaderProps): JSX.Element {
     return (
         <div className='m-3 flex justify-center'>
             {[...Array(count)].map((x, i) => (
                 <div key={i} className='overflow-x-hidden'>
-                    <ShowCardPlaceholder count={1} />
+                    <ShowCardLoader count={1} />
                 </div>
             ))}
         </div>

--- a/src/components/loaders/ShowListCardLoader.tsx
+++ b/src/components/loaders/ShowListCardLoader.tsx
@@ -1,7 +1,7 @@
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
 
-interface ShowListCardPlaceholderProps {
+interface ShowListCardLoaderProps {
     /**
      * Number of skeleton loaders to display
      */
@@ -15,9 +15,7 @@ interface ShowListCardPlaceholderProps {
  * @param count | number of card placeholders to be rendered
  * @returns {JSX.Element}
  */
-export default function ShowListCardPlaceholder({
-    count,
-}: ShowListCardPlaceholderProps): JSX.Element {
+export default function ShowListCardLoader({ count }: ShowListCardLoaderProps): JSX.Element {
     return (
         <div className='m-3 grid grid-cols-1 xl:grid-cols-2'>
             {[...Array(count)].map((x, i) => (

--- a/src/components/loaders/index.ts
+++ b/src/components/loaders/index.ts
@@ -1,0 +1,6 @@
+import ProvidersLoader from './ProvidersLoader';
+import ShowCardLoader from './ShowCardLoader';
+import ShowCarouselLoader from './ShowCarouselLoader';
+import ShowListCardLoader from './ShowListCardLoader';
+
+export { ProvidersLoader, ShowCardLoader, ShowCarouselLoader, ShowListCardLoader };

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -11,7 +11,7 @@ import { Navigate, useNavigate } from 'react-router-dom';
 import { Button, FilledInput, FormControl, InputLabel, Typography } from '@mui/material';
 import { Edit, Language, Logout, NoAdultContent } from '@mui/icons-material';
 import { ShowData } from '../types';
-import { ShowCarousel, ShowCarouselPlaceholder } from '../components';
+import { ShowCarousel, ShowCarouselLoader } from '../components';
 import { SUPABASE, getMovieDetails, getTvDetails } from '../helpers';
 import Logger from '../logger';
 
@@ -180,11 +180,7 @@ export default function DashboardScreen(): JSX.Element {
                 </Button>
             </div>
             <div>
-                {watchQueue ? (
-                    <ShowCarousel data={watchQueue} />
-                ) : (
-                    <ShowCarouselPlaceholder count={5} />
-                )}
+                {watchQueue ? <ShowCarousel data={watchQueue} /> : <ShowCarouselLoader count={5} />}
             </div>
         </section>
     );

--- a/src/screens/FeaturedSearchScreen.tsx
+++ b/src/screens/FeaturedSearchScreen.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { ShowCarousel, ShowCarouselPlaceholder, SearchInput } from '../components';
+import { ShowCarousel, ShowCarouselLoader, SearchInput } from '../components';
 import type { ShowData } from '../types';
 import { getMovieTrending, getTvTrending } from '../helpers';
 
@@ -29,11 +29,7 @@ export default function FeaturedSearchScreen(): JSX.Element {
             <h1 data-testid='featured-search-heading'>Featured Search Page</h1>
             <SearchInput />
 
-            {loading ? (
-                <ShowCarouselPlaceholder count={4} />
-            ) : (
-                <ShowCarousel data={trendingShows} />
-            )}
+            {loading ? <ShowCarouselLoader count={4} /> : <ShowCarousel data={trendingShows} />}
         </div>
     );
 }

--- a/src/screens/SearchResultsScreen.tsx
+++ b/src/screens/SearchResultsScreen.tsx
@@ -2,13 +2,13 @@ import { useLoaderData } from 'react-router-dom';
 import { useState, useEffect, useMemo } from 'react';
 import {
     ShowCard,
-    ShowListCard,
     ShowCardProps,
+    ShowCardLoader,
+    ShowListCard,
     ShowListCardProps,
-    ShowListCardPlaceholder,
+    ShowListCardLoader,
 } from '../components';
 import { ShowData } from '../types';
-import ShowCardPlaceholder from '../components/ShowCardPlaceholder';
 import { useProfileContext, useWindowSize } from '../hooks';
 import { ToggleButton, Tooltip, Typography } from '@mui/material';
 import { ViewList, ViewModule } from '@mui/icons-material';
@@ -106,9 +106,9 @@ export default function SearchResultsScreen(): JSX.Element {
                     Search results for: {query}
                 </Typography>
                 {(windowSize.width && windowSize.width < 750) || viewState === 'grid' ? (
-                    <ShowCardPlaceholder count={10} />
+                    <ShowCardLoader count={10} />
                 ) : (
-                    <ShowListCardPlaceholder count={10} />
+                    <ShowListCardLoader count={10} />
                 )}
             </div>
         );

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -9,7 +9,7 @@ import {
     getTvRecommendations,
 } from '../helpers';
 import { ShowData } from '../types';
-import { Providers, ShowCarousel, ShowCarouselPlaceholder } from '../components';
+import { Providers, ShowCarousel, ShowCarouselLoader } from '../components';
 import { Typography } from '@mui/material';
 import Rating from '../components/Rating';
 
@@ -54,7 +54,7 @@ export default function ShowDetailsScreen(): JSX.Element {
         return recommendations ? (
             <ShowCarousel data={recommendations} />
         ) : (
-            <ShowCarouselPlaceholder count={1} />
+            <ShowCarouselLoader count={1} />
         );
     }, [recommendations]);
 

--- a/src/stories/components/ProvidersLoader.stories.ts
+++ b/src/stories/components/ProvidersLoader.stories.ts
@@ -1,20 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ShowListCardPlaceholder } from '../../components';
+import { ProvidersLoader } from '../../components';
 
 const meta = {
-    title: 'Components/Show List Card Placeholder',
-    component: ShowListCardPlaceholder,
+    title: 'Components/Providers Loader',
+    component: ProvidersLoader,
     tags: ['autodocs'],
     parameters: {
         layout: 'centered',
     },
-} satisfies Meta<typeof ShowListCardPlaceholder>;
+} satisfies Meta<typeof ProvidersLoader>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {
     args: {
-        count: 1,
+        count: 4,
     },
 };

--- a/src/stories/components/ShowCardLoader.stories.ts
+++ b/src/stories/components/ShowCardLoader.stories.ts
@@ -1,20 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ProvidersPlaceholder } from '../../components';
+import { ShowCardLoader } from '../../components';
 
 const meta = {
-    title: 'Components/Providers Placeholder',
-    component: ProvidersPlaceholder,
+    title: 'Components/Show Card Loader',
+    component: ShowCardLoader,
     tags: ['autodocs'],
     parameters: {
         layout: 'centered',
     },
-} satisfies Meta<typeof ProvidersPlaceholder>;
+} satisfies Meta<typeof ShowCardLoader>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {
     args: {
-        count: 4,
+        count: 1,
     },
 };

--- a/src/stories/components/ShowCarouselLoader.stories.ts
+++ b/src/stories/components/ShowCarouselLoader.stories.ts
@@ -1,16 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ShowCarouselPlaceholder } from '../../components';
+import { ShowCarouselLoader } from '../../components';
 import { withRouter } from 'storybook-addon-react-router-v6';
 
 const meta = {
-    title: 'Components/Show Carousel Placeholder',
-    component: ShowCarouselPlaceholder,
+    title: 'Components/Show Carousel Loader',
+    component: ShowCarouselLoader,
     tags: ['autodocs'],
     parameters: {
         layout: 'centered',
     },
     decorators: [withRouter],
-} satisfies Meta<typeof ShowCarouselPlaceholder>;
+} satisfies Meta<typeof ShowCarouselLoader>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/stories/components/ShowListCardLoader.stories.ts
+++ b/src/stories/components/ShowListCardLoader.stories.ts
@@ -1,14 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ShowCardPlaceholder } from '../../components';
+import { ShowListCardLoader } from '../../components';
 
 const meta = {
-    title: 'Components/Show Card Placeholder',
-    component: ShowCardPlaceholder,
+    title: 'Components/Show List Card Loader',
+    component: ShowListCardLoader,
     tags: ['autodocs'],
     parameters: {
         layout: 'centered',
     },
-} satisfies Meta<typeof ShowCardPlaceholder>;
+} satisfies Meta<typeof ShowListCardLoader>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;


### PR DESCRIPTION
# ❌ Do not merge until #485 is merged

Changed the naming convention from 'Placeholders' to 'Loaders'. The idea here is that placeholders are used when there is no data, loaders are used when awaiting data. If we know there is no data, a loader should not be used as it indicates to the user more content is loading.

Closed #471 