### PR TITLE
Show poster loader

### DIFF
--- a/src/components/ShowCarousel.tsx
+++ b/src/components/ShowCarousel.tsx
@@ -1,11 +1,10 @@
 import Carousel from 'nuka-carousel';
 import { ShowData } from '../types/tmdb';
 import { useEffect, useState } from 'react';
-import { useWindowSize } from '../hooks';
-import useDebounce from '../hooks/useDebounceValue';
+import { useWindowSize, useDebounceValue } from '../hooks';
 import ShowPoster, { SHOW_POSTER_WIDTH } from './ShowPoster';
 import { WindowSize } from '../hooks/useWIndowSize';
-import { ShowCarouselLoader } from './loaders';
+import { ShowPosterLoader } from './loaders';
 import { Typography } from '@mui/material';
 
 interface ShowCarouselProps {
@@ -67,7 +66,7 @@ function CarouselChildren({ data }: { data: ShowData[] }): JSX.Element {
  */
 export default function ShowCarousel({ data, size, isLoading }: ShowCarouselProps): JSX.Element {
     const windowSize = useWindowSize();
-    const debouncedWindowSize = useDebounce(windowSize, 250);
+    const debouncedWindowSize = useDebounceValue(windowSize, 250);
     const [loading, setLoading] = useState(isLoading);
     const [carouselSteps, setCarouselSteps] = useState<number>(
         size || getCarouselSteps(windowSize)
@@ -125,8 +124,8 @@ export default function ShowCarousel({ data, size, isLoading }: ShowCarouselProp
     if (loading) {
         return (
             <section className='pt-12'>
-                <div className={`w-[${carouselWidth}]`}>
-                    <ShowCarouselLoader count={getCarouselSteps(windowSize)} />
+                <div className={`w-[${carouselWidth}] flex justify-center`}>
+                    <ShowPosterLoader count={getCarouselSteps(windowSize)} />
                 </div>
             </section>
         );

--- a/src/components/loaders/ShowPosterLoader.tsx
+++ b/src/components/loaders/ShowPosterLoader.tsx
@@ -1,0 +1,27 @@
+import Skeleton from 'react-loading-skeleton';
+import 'react-loading-skeleton/dist/skeleton.css';
+
+interface ShowCardLoaderProps {
+    /**
+     * Number of skeleton loaders to display
+     */
+    count: number;
+}
+
+/**
+ * A skeleton loader of the show poster component. To be rendered while
+ * main component is loading.
+ * @param count | number of poster placeholders to be rendered
+ * @returns {JSX.Element}
+ */
+export default function ShowPosterLoader({ count }: ShowCardLoaderProps): JSX.Element {
+    return (
+        <>
+            {[...Array(count)].map((x, i) => (
+                <div key={i} className='flex w-[180px] mx-1 my-2'>
+                    <Skeleton width={175} height={270} className='mb-2 my-1' />
+                </div>
+            ))}
+        </>
+    );
+}

--- a/src/components/loaders/index.ts
+++ b/src/components/loaders/index.ts
@@ -2,5 +2,12 @@ import ProvidersLoader from './ProvidersLoader';
 import ShowCardLoader from './ShowCardLoader';
 import ShowCarouselLoader from './ShowCarouselLoader';
 import ShowListCardLoader from './ShowListCardLoader';
+import ShowPosterLoader from './ShowPosterLoader';
 
-export { ProvidersLoader, ShowCardLoader, ShowCarouselLoader, ShowListCardLoader };
+export {
+    ProvidersLoader,
+    ShowCardLoader,
+    ShowCarouselLoader,
+    ShowListCardLoader,
+    ShowPosterLoader,
+};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 import { useProfileContext, useSessionContext } from './context';
 import useWindowSize from './useWIndowSize';
 import useIsInWatchQueue from './useIsInWatchQueue';
+import useDebounceValue from './useDebounceValue';
 
-export { useProfileContext, useSessionContext, useIsInWatchQueue, useWindowSize };
+export { useProfileContext, useSessionContext, useIsInWatchQueue, useWindowSize, useDebounceValue };

--- a/src/stories/loaders/ProvidersLoader.stories.ts
+++ b/src/stories/loaders/ProvidersLoader.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { ProvidersLoader } from '../../components';
 
 const meta = {
-    title: 'Components/Providers Loader',
+    title: 'Loaders/Providers',
     component: ProvidersLoader,
     tags: ['autodocs'],
     parameters: {

--- a/src/stories/loaders/ShowCardLoader.stories.ts
+++ b/src/stories/loaders/ShowCardLoader.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ShowCardLoader } from '../../components';
+
+const meta = {
+    title: 'Loaders/Show Card',
+    component: ShowCardLoader,
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'centered',
+    },
+} satisfies Meta<typeof ShowCardLoader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+    args: {
+        count: 1,
+    },
+};

--- a/src/stories/loaders/ShowCarouselLoader.stories.ts
+++ b/src/stories/loaders/ShowCarouselLoader.stories.ts
@@ -3,7 +3,7 @@ import { ShowCarouselLoader } from '../../components';
 import { withRouter } from 'storybook-addon-react-router-v6';
 
 const meta = {
-    title: 'Components/Show Carousel Loader',
+    title: 'Loaders/Show Carousel',
     component: ShowCarouselLoader,
     tags: ['autodocs'],
     parameters: {

--- a/src/stories/loaders/ShowListCardLoader.stories.ts
+++ b/src/stories/loaders/ShowListCardLoader.stories.ts
@@ -1,14 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ShowCardLoader } from '../../components';
+import { ShowListCardLoader } from '../../components';
 
 const meta = {
-    title: 'Components/Show Card Loader',
-    component: ShowCardLoader,
+    title: 'Loaders/Show List Card',
+    component: ShowListCardLoader,
     tags: ['autodocs'],
     parameters: {
         layout: 'centered',
     },
-} satisfies Meta<typeof ShowCardLoader>;
+} satisfies Meta<typeof ShowListCardLoader>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/stories/loaders/ShowPosterLoader.stories.ts
+++ b/src/stories/loaders/ShowPosterLoader.stories.ts
@@ -1,14 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ShowListCardLoader } from '../../components';
+import { ShowPosterLoader } from '../../components';
 
 const meta = {
-    title: 'Components/Show List Card Loader',
-    component: ShowListCardLoader,
+    title: 'Loaders/Show Poster',
+    component: ShowPosterLoader,
     tags: ['autodocs'],
     parameters: {
         layout: 'centered',
     },
-} satisfies Meta<typeof ShowListCardLoader>;
+} satisfies Meta<typeof ShowPosterLoader>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;


### PR DESCRIPTION
# ❌ Wait for #489 & #492 

Created show poster loader component and story. Used loader in the carousel component. I also refactored the stories directory to split up loaders as we did in the components dir.

Closes #491 

## Screenshots

![image](https://github.com/Thenlie/Streamability/assets/41388783/45ca87de-ab68-4d97-b95a-718754a851d2)
![image](https://github.com/Thenlie/Streamability/assets/41388783/17331e9e-01a8-4248-9a31-41129d334c9b)
