### PR TITLE
#487 add no data state to carousel

### DIFF
--- a/src/components/ShowCarousel.tsx
+++ b/src/components/ShowCarousel.tsx
@@ -17,6 +17,11 @@ interface ShowCarouselProps {
      * If `undefined` this number will be based on screen size
      */
     size?: number | undefined;
+    /**
+     * Text to be shown if there is no data to display
+     * in the carousel
+     */
+    fallbackText?: string;
 }
 
 /**
@@ -60,7 +65,7 @@ function CarouselChildren({ data }: { data: ShowData[] }): JSX.Element {
  *
  * @returns {JSX.Element} | Carousel of movie cards
  */
-export default function ShowCarousel({ data, size }: ShowCarouselProps): JSX.Element {
+export default function ShowCarousel({ data, size, fallbackText }: ShowCarouselProps): JSX.Element {
     const windowSize = useWindowSize();
     const debouncedWindowSize = useDebounceValue(windowSize, 250);
     const [loading, setLoading] = useState(true);
@@ -127,12 +132,33 @@ export default function ShowCarousel({ data, size }: ShowCarouselProps): JSX.Ele
         );
     }
 
-    // TODO: #487 Handle no data state
-    if (!data) {
+    if (!data || data.length === 0) {
         return (
             <section className='pt-12'>
                 <div className={`w-[${carouselWidth}]`}>
-                    <Typography variant='body1'>Sorry, no data!</Typography>
+                    <Carousel
+                        className='bg-primary'
+                        style={{
+                            width: carouselWidth,
+                            paddingTop: '10px',
+                            paddingBottom: '10px',
+                            borderRadius: '5px',
+                        }}
+                        defaultControlsConfig={{
+                            pagingDotsClassName: 'hidden',
+                            nextButtonClassName: 'hidden',
+                            prevButtonClassName: 'hidden',
+                        }}
+                    >
+                        <Typography
+                            variant='body1'
+                            className={'h-[270px] text-center pt-[100px] md:pt-[120px] p-3'}
+                        >
+                            {fallbackText
+                                ? fallbackText
+                                : 'Sorry, no shows to display at this time.'}
+                        </Typography>
+                    </Carousel>
                 </div>
             </section>
         );

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -32,6 +32,8 @@ export default function DashboardScreen(): JSX.Element {
     const [queue, setQueue] = useState<ShowData[] | null>(null);
     const navigate = useNavigate();
 
+    const fallbackText = 'Your queue is empty! Add shows to your watch queue to view them here.';
+
     if (!session) {
         return <Navigate to={'/auth/login'} />;
     }
@@ -197,11 +199,9 @@ export default function DashboardScreen(): JSX.Element {
                     </Button>
                 )}
             </div>
-            {queue && (
-                <div>
-                    <ShowCarousel data={queue} />
-                </div>
-            )}
+            <div>
+                <ShowCarousel data={queue} fallbackText={fallbackText} />
+            </div>
         </section>
     );
 }

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -29,6 +29,8 @@ export default function ShowDetailsScreen(): JSX.Element {
     const id = parseInt(location.pathname.split('/')[3]);
     const showType = location.pathname.split('/')[2];
 
+    const fallbackText = 'Sorry, we could not find any recommendations based on this title.';
+
     useEffect(() => {
         const handler = async () => {
             setLoading(true);
@@ -112,7 +114,7 @@ export default function ShowDetailsScreen(): JSX.Element {
                 </div>
             </section>
             <section className='pb-6'>
-                <ShowCarousel data={recommendations} />
+                <ShowCarousel data={recommendations} fallbackText={fallbackText} />
             </section>
         </>
     );


### PR DESCRIPTION
Added basic empty state for the carousel. Since the component can accept `null` for data, this is needed. I added an option prop `fallbackText` which will be the text displayed in this empty state. If that prop is not used, default text will be shown. If we do not want to render the carousel when data is null, we should make that conditional in the parent component.

## Screenshots

![image](https://github.com/Thenlie/Streamability/assets/41388783/f4d507eb-d1cb-4afc-8a22-31bfe1d8c7bd)
![image](https://github.com/Thenlie/Streamability/assets/41388783/8b4389a2-f9df-45e7-9bc6-6b644b5572b3)

Closes #487 