### PR TITLE
Show poster 'remove from queue' button

### DIFF
--- a/src/components/ShowCarousel.tsx
+++ b/src/components/ShowCarousel.tsx
@@ -22,6 +22,10 @@ interface ShowCarouselProps {
      * in the carousel
      */
     fallbackText?: string;
+    /**
+     * TODO:
+     */
+    removeFromQueue?: (showId: string) => Promise<void>;
 }
 
 /**
@@ -49,11 +53,19 @@ export function getCarouselSteps(windowSize: WindowSize): number {
  *
  * @returns {JSX.Element} | Collection of ShowCards
  */
-const CarouselChildren: React.FC<{ data: ShowData[] }> = ({ data }): JSX.Element => {
+const CarouselChildren: React.FC<{
+    data: ShowData[];
+    removeFromQueue?: (showId: string) => Promise<void>;
+}> = ({ data, removeFromQueue }): JSX.Element => {
     return (
         <div className='flex justify-center'>
             {data?.map((item, i) => (
-                <ShowPoster key={i} details={item} showType={item.media_type} />
+                <ShowPoster
+                    key={i}
+                    details={item}
+                    showType={item.media_type}
+                    removeFromQueue={removeFromQueue}
+                />
             ))}
         </div>
     );
@@ -65,7 +77,12 @@ const CarouselChildren: React.FC<{ data: ShowData[] }> = ({ data }): JSX.Element
  *
  * @returns {JSX.Element} | Carousel of movie cards
  */
-const ShowCarousel: React.FC<ShowCarouselProps> = ({ data, size, fallbackText }): JSX.Element => {
+const ShowCarousel: React.FC<ShowCarouselProps> = ({
+    data,
+    size,
+    fallbackText,
+    removeFromQueue,
+}): JSX.Element => {
     const windowSize = useWindowSize();
     const debouncedWindowSize = useDebounceValue(windowSize, 250);
     const [loading, setLoading] = useState(true);
@@ -116,7 +133,9 @@ const ShowCarousel: React.FC<ShowCarouselProps> = ({ data, size, fallbackText })
         if (data) {
             for (let i = 0; i < filteredArray.length; i += carouselSteps) {
                 const chunk = filteredArray.slice(i, i + carouselSteps);
-                arr.push(<CarouselChildren key={i} data={chunk} />);
+                arr.push(
+                    <CarouselChildren key={i} data={chunk} removeFromQueue={removeFromQueue} />
+                );
             }
         }
         return arr;

--- a/src/components/ShowPoster.tsx
+++ b/src/components/ShowPoster.tsx
@@ -1,7 +1,8 @@
 import { ShowData } from '../types';
 import { Link } from 'react-router-dom';
 import { CardMedia } from '@mui/material';
-import React from 'react';
+import React, { useState } from 'react';
+import { Delete } from '@mui/icons-material';
 
 export const SHOW_POSTER_WIDTH = 180;
 
@@ -14,6 +15,10 @@ export interface ShowPosterProps {
      * Either 'movie' or 'tv'
      */
     showType: string;
+    /**
+     * Remove a single show from the users queue
+     */
+    removeFromQueue?: (showId: string) => Promise<void>;
 }
 
 /**
@@ -24,12 +29,42 @@ export interface ShowPosterProps {
  * @param props | returns details object passed from SearchResultScreen.tsx
  * @returns {JSX.Element} | Single show card
  */
-const ShowPoster: React.FC<ShowPosterProps> = ({ details, showType }): JSX.Element => {
+const ShowPoster: React.FC<ShowPosterProps> = ({
+    details,
+    showType,
+    removeFromQueue,
+}): JSX.Element => {
+    const [hover, setHover] = useState(false);
+
+    const hoverHandler = (hovering: boolean) => {
+        setHover(hovering);
+    };
+
     return (
         <div
+            onMouseEnter={() => hoverHandler(true)}
+            onMouseLeave={() => hoverHandler(false)}
             data-testid='show-card-component'
             className='m-1 flex w-[180px] bg-foreground rounded-sm'
         >
+            {removeFromQueue && (
+                <div
+                    onClick={() => removeFromQueue(details.media_type + '-' + details.id)}
+                    className='cursor-pointer'
+                >
+                    <Delete
+                        color='error'
+                        fontSize='large'
+                        sx={{
+                            display: hover ? 'block' : 'none',
+                            position: 'relative',
+                            top: 5,
+                            right: -180,
+                            marginLeft: -4.4,
+                        }}
+                    />
+                </div>
+            )}
             <Link
                 to={`/details/${showType}/${details.id}`}
                 state={details}

--- a/src/components/ShowPoster.tsx
+++ b/src/components/ShowPoster.tsx
@@ -1,6 +1,6 @@
 import { ShowData } from '../types';
 import { Link } from 'react-router-dom';
-import { CardMedia } from '@mui/material';
+import { CardMedia, Tooltip } from '@mui/material';
 import React, { useState } from 'react';
 import { Delete } from '@mui/icons-material';
 
@@ -45,25 +45,30 @@ const ShowPoster: React.FC<ShowPosterProps> = ({
             onMouseEnter={() => hoverHandler(true)}
             onMouseLeave={() => hoverHandler(false)}
             data-testid='show-card-component'
-            className='m-1 flex w-[180px] bg-foreground rounded-sm'
+            className='m-1 flex w-[180px] rounded-sm'
         >
             {removeFromQueue && (
-                <div
-                    onClick={() => removeFromQueue(details.media_type + '-' + details.id)}
-                    className='cursor-pointer'
-                >
-                    <Delete
-                        color='error'
-                        fontSize='large'
-                        sx={{
-                            display: hover ? 'block' : 'none',
-                            position: 'relative',
-                            top: 5,
-                            right: -180,
-                            marginLeft: -4.4,
-                        }}
-                    />
-                </div>
+                <Tooltip title='Remove from Queue' placement='right-start' className='mt-2'>
+                    <div
+                        onClick={() => removeFromQueue(details.media_type + '-' + details.id)}
+                        className='cursor-pointer'
+                    >
+                        <Delete
+                            titleAccess={`Remove ${details.title} from queue`}
+                            color='error'
+                            fontSize='large'
+                            className='bg-transprimary rounded-full p-[2px]'
+                            sx={{
+                                display: hover ? 'block' : 'none',
+                                position: 'relative',
+                                top: 0,
+                                right: -175,
+                                marginLeft: -4.4,
+                                zIndex: 1,
+                            }}
+                        />
+                    </div>
+                </Tooltip>
             )}
             <Link
                 to={`/details/${showType}/${details.id}`}
@@ -72,8 +77,15 @@ const ShowPoster: React.FC<ShowPosterProps> = ({
             >
                 <CardMedia
                     component='img'
-                    className='w-full cursor-pointer rounded-l-sm'
-                    sx={{ width: 180, minWidth: 180, height: 270, minHeight: 270 }}
+                    className='w-full cursor-pointer rounded-sm'
+                    sx={{
+                        width: 180,
+                        minWidth: 180,
+                        height: 270,
+                        minHeight: 270,
+                        boxShadow: 5,
+                        '&:hover': { opacity: 0.8 },
+                    }}
                     image={
                         details.poster_path
                             ? `https://image.tmdb.org/t/p/w500${details.poster_path}`

--- a/src/index.css
+++ b/src/index.css
@@ -36,7 +36,7 @@
 
 @font-face {
   font-family: 'sunday-grapes';
-  src: url('/public/fonts/Sunday\ Grapes.ttf');
+  src: url('/fonts/Sunday\ Grapes.ttf');
 }
 
 input:-webkit-autofill,

--- a/src/index.css
+++ b/src/index.css
@@ -30,7 +30,7 @@
 
 @layer components {
   .btn {
-    @apply bg-highlight py-2 px-4 rounded hover: bg-hlhover
+    @apply bg-highlight py-2 px-4 rounded hover:bg-hlhover
   }
 }
 

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useSessionContext, useProfileContext } from '../hooks';
-import { deleteProfileById, getProfileQueue, removeProfileArray } from '../supabase/profiles';
+import {
+    deleteProfileById,
+    getProfileQueue,
+    removeFromProfileArray,
+    removeProfileArray,
+} from '../supabase/profiles';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { Typography } from '@mui/material';
 import { Delete, Logout } from '@mui/icons-material';
@@ -53,7 +58,7 @@ const DashboardScreen: React.FC = (): JSX.Element => {
             LOG.debug(String(queue));
         };
         handler();
-    }, [session]);
+    }, [session, profile]);
 
     /**
      * Delete profile row and auth entry.
@@ -78,6 +83,14 @@ const DashboardScreen: React.FC = (): JSX.Element => {
         if (session) {
             await removeProfileArray(session.user.id, 'queue');
             setQueue(null);
+        }
+    };
+
+    const removeFromQueue = async (showId: string) => {
+        if (profile) {
+            const res = await removeFromProfileArray(profile.id, showId, 'queue');
+            if (!res) return;
+            setProfile(res);
         }
     };
 
@@ -148,7 +161,11 @@ const DashboardScreen: React.FC = (): JSX.Element => {
                     <ConfirmDeleteModal deleteProfile={deleteProfile} loading={deleteLoading} />
                 </div>
                 <div>
-                    <ShowCarousel data={queue} fallbackText={fallbackText} />
+                    <ShowCarousel
+                        data={queue}
+                        fallbackText={fallbackText}
+                        removeFromQueue={removeFromQueue}
+                    />
                     <Button
                         title='Clear Queue'
                         color='error'

--- a/src/stories/components/ShowPoster.stories.ts
+++ b/src/stories/components/ShowPoster.stories.ts
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ShowPoster } from '../../components';
+import { MOVIE_DATA } from '../../__tests__/screens/assets';
+import { withRouter } from 'storybook-addon-react-router-v6';
+
+const removeFromQueueMock = async () => {
+    return;
+};
+
+const meta = {
+    title: 'Components/Show Poster',
+    component: ShowPoster,
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'centered',
+    },
+    decorators: [withRouter],
+} satisfies Meta<typeof ShowPoster>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+    args: {
+        details: MOVIE_DATA[0],
+        showType: 'movie',
+        removeFromQueue: removeFromQueueMock,
+    },
+};

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -9,6 +9,7 @@ module.exports = {
                 background: 'rgb(var(--color-background))',
                 foreground: 'rgb(var(--color-foreground))',
                 primary: 'rgb(var(--color-primary))',
+                transprimary: 'rgb(var(--color-primary) / 0.5)',
                 text: 'rgb(var(--color-text))',
                 highlight: 'rgb(var(--color-highlight))',
                 hlhover: 'rgb(var(--color-hlhover))',


### PR DESCRIPTION
Added a button to remove a single show from the users queue. This will show only on the dashboard queue carousel.

Also created a show poster storybook as that was missed in my initial work.

## Demo 🎥 

https://github.com/Thenlie/Streamability/assets/41388783/1a00cb09-3627-4e53-a3a0-28813912f25f

Closes #508
