### PR TITLE
Sorting search results

### DIFF
--- a/src/helpers/getShowUtils.ts
+++ b/src/helpers/getShowUtils.ts
@@ -1,5 +1,6 @@
+/* eslint-disable prettier/prettier */
 import Logger from '../logger';
-import { ShowData, ShowResults } from '../types';
+import { MovieData, ShowData, ShowResults, TvData } from '../types';
 
 const LOG = new Logger('getShowUtils');
 
@@ -16,6 +17,7 @@ const getShowsByName = async (name: string): Promise<ShowData[] | null> => {
     );
     if (!response.ok) {
         LOG.error('Fetch request failed with a status of ' + response.status);
+        return null;
     }
     const data = (await response.json()) as ShowResults;
     if (!data.results) {
@@ -23,17 +25,26 @@ const getShowsByName = async (name: string): Promise<ShowData[] | null> => {
         return null;
     }
     return data.results.map((show) => {
-        return {
+        const obj = {
             id: show.id,
             poster_path: show.poster_path,
-            title: show.title,
-            release_date: show.release_date,
             vote_average: show.vote_average,
             vote_count: show.vote_count,
             overview: show.overview,
             media_type: show.media_type,
             genre_ids: show.genre_ids,
         };
+        return show.media_type === 'movie'
+            ? {
+                ...obj,
+                title: (show as MovieData).title,
+                release_date: (show as MovieData).release_date,
+            }
+            : {
+                ...obj,
+                title: (show as TvData).name,
+                release_date: (show as TvData).first_air_date,
+            };
     });
 };
 

--- a/src/helpers/getShowUtils.ts
+++ b/src/helpers/getShowUtils.ts
@@ -25,7 +25,7 @@ const getShowsByName = async (name: string): Promise<ShowData[] | null> => {
         return null;
     }
     return data.results.map((show) => {
-        const obj = {
+        return {
             id: show.id,
             poster_path: show.poster_path,
             vote_average: show.vote_average,
@@ -33,18 +33,9 @@ const getShowsByName = async (name: string): Promise<ShowData[] | null> => {
             overview: show.overview,
             media_type: show.media_type,
             genre_ids: show.genre_ids,
+            title: show.media_type === 'movie' ? (show as MovieData).title : (show as TvData).name,
+            release_date: show.media_type === 'movie' ? (show as MovieData).release_date : (show as TvData).first_air_date,
         };
-        return show.media_type === 'movie'
-            ? {
-                ...obj,
-                title: (show as MovieData).title,
-                release_date: (show as MovieData).release_date,
-            }
-            : {
-                ...obj,
-                title: (show as TvData).name,
-                release_date: (show as TvData).first_air_date,
-            };
     });
 };
 

--- a/src/screens/SearchResultsScreen.tsx
+++ b/src/screens/SearchResultsScreen.tsx
@@ -1,5 +1,5 @@
 import { useLoaderData } from 'react-router-dom';
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
     ShowCard,
     ShowCardProps,
@@ -11,9 +11,12 @@ import {
 } from '../components';
 import { ShowData } from '../types';
 import { useProfileContext, useWindowSize } from '../hooks';
-import { ToggleButton, Tooltip, Typography as Typ } from '@mui/material';
+import { SvgIcon, ToggleButton, ToggleButtonGroup, Typography as Typ } from '@mui/material';
 import { ViewList, ViewModule } from '@mui/icons-material';
-import { getShowsByName } from '../helpers';
+import { getShowsByName, sortShowsAlphaAsc, sortShowsAlphaDesc } from '../helpers';
+import Logger from '../logger';
+
+const LOG = new Logger('SearchResultsScreen');
 
 /**
  * This loader is mostly built straight from the react-router docs
@@ -33,17 +36,54 @@ export async function loader({ request }: { request: Request }): Promise<string>
 }
 
 /**
- * The page displayed after a user makes a search query
- *
- * @returns {JSX.Element}
+ * Loops over show details and creates an array of show cards
+ * using the correct component based on the `viewState`
  */
-const SearchResultsScreen: React.FC = (): JSX.Element => {
-    const query: string = useLoaderData() as string;
+const SearchResultCards: React.FC<{ details: ShowData[] | null; viewState: 'grid' | 'list' }> = ({
+    details,
+    viewState,
+}) => {
     const { profile, setProfile } = useProfileContext();
+
+    const CardComp: React.FC<ShowCardProps | ShowListCardProps> = (props) => {
+        return viewState === 'grid' ? <ShowCard {...props} /> : <ShowListCard {...props} />;
+    };
+
+    return (
+        <div
+            className={`${
+                viewState === 'grid'
+                    ? 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
+                    : 'flex flex-wrap justify-center'
+            } pb-6
+            `}
+        >
+            {details?.map((item, i) => {
+                return (
+                    <CardComp
+                        key={i}
+                        details={item}
+                        showType={item.media_type}
+                        profile={profile}
+                        setProfile={setProfile}
+                    />
+                );
+            })}
+        </div>
+    );
+};
+
+/**
+ * The page displayed after a user makes a search query.
+ * A gallery of shows that are linked to detail pages.
+ */
+const SearchResultsScreen: React.FC = () => {
+    const query: string = useLoaderData() as string;
     const windowSize = useWindowSize();
     const storageItem = localStorage.getItem('streamabilityView');
     const initialView = storageItem === 'grid' ? 'grid' : 'list';
     const [viewState, setViewState] = useState<'list' | 'grid'>(initialView);
+    const [sortState, setSortState] = useState<'alpha' | 'rev' | 'none'>('none');
     const [showDetails, setShowDetails] = useState<ShowData[] | null>(null);
     const [loading, setLoading] = useState<boolean>(true);
 
@@ -62,80 +102,122 @@ const SearchResultsScreen: React.FC = (): JSX.Element => {
         const handler = async () => {
             const showData: ShowData[] | null = await getShowsByName(query);
             setShowDetails(showData);
+            localStorage.setItem('streamabilityUnsortedResults', JSON.stringify(showData));
             setLoading(false);
         };
         handler();
     }, [query]);
 
-    const handleViewToggle = useCallback(() => {
-        setViewState((prev) => (prev === 'grid' ? 'list' : 'grid'));
-        const view = localStorage.getItem('streamabilityView');
-        localStorage.setItem('streamabilityView', view === 'grid' ? 'list' : 'grid');
-    }, [setViewState]);
+    const handleViewToggle = (view: 'grid' | 'list') => {
+        setViewState(view);
+        localStorage.setItem('streamabilityView', view);
+    };
+
+    const handleSortAlpha = () => {
+        const sortedShows = sortShowsAlphaAsc(showDetails || []);
+        setShowDetails(sortedShows);
+        setSortState('alpha');
+    };
+
+    const handleSortRevAlpha = () => {
+        const sortedShows = sortShowsAlphaDesc(showDetails || []);
+        setShowDetails(sortedShows);
+        setSortState('rev');
+    };
+
+    const handleRemoveSort = () => {
+        const unsortedShows = localStorage.getItem('streamabilityUnsortedResults');
+        if (!unsortedShows) {
+            LOG.error('Unable to un-sort shows!');
+            return;
+        }
+        setShowDetails(JSON.parse(unsortedShows));
+        setSortState('none');
+    };
 
     /**
      * Heading of the screen showing the search query
      * and containing the view toggle button.
      */
-    const SearchResultHeader = useMemo((): JSX.Element => {
+    const SearchResultHeader: React.FC = () => {
         return (
-            <div className='flex justify-between align-middle w-full p-3'>
-                <Typ variant='h5' data-testid='search-results-heading'>
-                    Search results for: {query}
+            <div className='flex flex-wrap justify-between align-middle w-full p-3'>
+                <Typ
+                    variant='h5'
+                    data-testid='search-results-heading'
+                    alignSelf='center'
+                    margin={1}
+                >
+                    Search results for: <span className='underline'>{query}</span>
                 </Typ>
-                <Tooltip title='toggle card view'>
-                    <ToggleButton
+                <div>
+                    <ToggleButtonGroup value={sortState} exclusive sx={{ marginRight: 2 }}>
+                        <ToggleButton
+                            value='alpha'
+                            aria-label='sort results alphabetically'
+                            onClick={handleSortAlpha}
+                        >
+                            <SvgIcon>
+                                <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+                                    <title>sort-alphabetical-ascending</title>
+                                    <path d='M19 17H22L18 21L14 17H17V3H19M11 13V15L7.67 19H11V21H5V19L8.33 15H5V13M9 3H7C5.9 3 5 3.9 5 5V11H7V9H9V11H11V5C11 3.9 10.11 3 9 3M9 7H7V5H9Z' />
+                                </svg>
+                            </SvgIcon>
+                        </ToggleButton>
+                        <ToggleButton
+                            value='rev'
+                            aria-label='sort results reverse alphabetically'
+                            onClick={handleSortRevAlpha}
+                        >
+                            <SvgIcon>
+                                <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+                                    <title>sort-alphabetical-descending</title>
+                                    <path d='M19 7H22L18 3L14 7H17V21H19M11 13V15L7.67 19H11V21H5V19L8.33 15H5V13M9 3H7C5.9 3 5 3.9 5 5V11H7V9H9V11H11V5C11 3.9 10.11 3 9 3M9 7H7V5H9Z' />
+                                </svg>
+                            </SvgIcon>
+                        </ToggleButton>
+                        <ToggleButton
+                            value='none'
+                            aria-label='Remove sort'
+                            onClick={handleRemoveSort}
+                        >
+                            <SvgIcon>
+                                <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
+                                    <title>sort-variant-remove</title>
+                                    <path d='M3 13H15V11H3M3 6V8H21V6M3 18H9V16H3V18M22.54 16.88L20.41 19L22.54 21.12L21.12 22.54L19 20.41L16.88 22.54L15.47 21.12L17.59 19L15.47 16.88L16.88 15.47L19 17.59L21.12 15.46L22.54 16.88' />
+                                </svg>
+                            </SvgIcon>
+                        </ToggleButton>
+                    </ToggleButtonGroup>
+                    <ToggleButtonGroup
+                        value={viewState}
+                        exclusive
                         sx={windowSize.width && windowSize.width < 750 ? { display: 'none' } : {}}
-                        value='toggle card view'
-                        aria-label='toggle card view'
-                        onClick={handleViewToggle}
                     >
-                        {viewState === 'grid' ? <ViewList /> : <ViewModule />}
-                    </ToggleButton>
-                </Tooltip>
+                        <ToggleButton
+                            value='grid'
+                            aria-label='switch to grid view'
+                            onClick={() => handleViewToggle('grid')}
+                        >
+                            <ViewModule />
+                        </ToggleButton>
+                        <ToggleButton
+                            value='list'
+                            aria-label='switch to list view'
+                            onClick={() => handleViewToggle('list')}
+                        >
+                            <ViewList />
+                        </ToggleButton>
+                    </ToggleButtonGroup>
+                </div>
             </div>
         );
-    }, [query, viewState]);
-
-    /**
-     * Loops over show details and creates an array of show cards
-     * using the correct component based on the `viewState`
-     *
-     * @returns {JSX.Element}
-     */
-    const SearchResultCards = useMemo((): JSX.Element => {
-        const CardComp: React.FC<ShowCardProps | ShowListCardProps> = (props) => {
-            return viewState === 'grid' ? <ShowCard {...props} /> : <ShowListCard {...props} />;
-        };
-
-        return (
-            <div
-                className={`${
-                    viewState === 'grid'
-                        ? 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
-                        : 'flex flex-wrap justify-center'
-                } pb-6
-                `}
-            >
-                {showDetails?.map((item, i) => {
-                    return (
-                        <CardComp
-                            key={i}
-                            details={item}
-                            showType={item.media_type}
-                            profile={profile}
-                            setProfile={setProfile}
-                        />
-                    );
-                })}
-            </div>
-        );
-    }, [showDetails, viewState, profile]);
+    };
 
     if (loading) {
         return (
             <>
-                {SearchResultHeader}
+                <SearchResultHeader />
                 <div
                     className={
                         viewState === 'grid'
@@ -159,8 +241,8 @@ const SearchResultsScreen: React.FC = (): JSX.Element => {
 
     return (
         <>
-            {SearchResultHeader}
-            {SearchResultCards}
+            <SearchResultHeader />
+            <SearchResultCards details={showDetails} viewState={viewState} />
         </>
     );
 };

--- a/src/types/tmdb/movie.ts
+++ b/src/types/tmdb/movie.ts
@@ -5,10 +5,11 @@ import { ShowGenre } from './show';
  * https://developer.themoviedb.org/reference/search-movie
  */
 export interface MovieData {
+    id: number;
+    media_type: 'movie' | 'tv';
     adult: boolean;
     backdrop_path: string | null;
     genre_ids?: number[];
-    id: number;
     original_language: string;
     original_title: string;
     overview: string;

--- a/src/types/tmdb/show.ts
+++ b/src/types/tmdb/show.ts
@@ -1,3 +1,6 @@
+import { MovieData } from './movie';
+import { TvData } from './tv';
+
 /**
  * Object containing genre as string and TMDB genre id
  * https://developer.themoviedb.org/reference/genre-movie-list
@@ -117,7 +120,7 @@ export interface ShowData {
  */
 export interface ShowResults {
     page?: number;
-    results?: ShowData[];
+    results?: Array<MovieData | TvData>;
     total_pages?: number;
     total_results?: number;
 }

--- a/src/types/tmdb/tv.ts
+++ b/src/types/tmdb/tv.ts
@@ -6,6 +6,7 @@ import { ShowGenre } from './show';
  */
 export interface TvData {
     id: number;
+    media_type: 'movie' | 'tv';
     backdrop_path?: string | null;
     genre_ids?: number[];
     original_language?: string;


### PR DESCRIPTION
Added alphabetical sorting to the search results screen. This probably won't get used a ton since you will want to see best results first, but the pattern can be used on Discover screen as well. I also added a 'remove sort' button and cache the original results order in local storage.

Additionally I found a bug with my implementation of multi search. It had actually broken TV shows. So I fix that here as well.

## Screenshot

<img width="840" alt="image" src="https://github.com/Thenlie/Streamability/assets/41388783/94ca0730-fccd-4b21-a2cf-dee8cc377702">

Closes #490 