### PR TITLE
524 refactor text input component

### DIFF
--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -19,8 +19,9 @@ const SearchInput: React.FC = (): JSX.Element => {
                 type='text'
                 name='q'
                 label='Search'
+                color='secondary'
                 variant='outlined'
-                aria-label='search'
+                ariaLabel='search'
                 inputProps={{
                     'data-testid': 'search-input',
                 }}

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,7 +1,8 @@
 import { Search } from '@mui/icons-material';
-import { FormControl, IconButton, Input, InputAdornment, InputLabel } from '@mui/material';
+import { IconButton, InputAdornment } from '@mui/material';
 import React from 'react';
 import { Form } from 'react-router-dom';
+import TextInput from '../components/TextInput';
 
 /**
  * Currently using a react router form,
@@ -14,29 +15,24 @@ const SearchInput: React.FC = (): JSX.Element => {
     return (
         // TODO: #162 Use MUI ThemeProvider
         <Form method='get' action='/search'>
-            <FormControl variant='filled'>
-                <InputLabel htmlFor='q' color='secondary' className='!text-text'>
-                    Search
-                </InputLabel>
-                <Input
-                    type='text'
-                    name='q'
-                    color='secondary'
-                    className='!text-text'
-                    aria-label='search'
-                    inputProps={{
-                        'data-testid': 'search-input',
-                    }}
-                    required
-                    endAdornment={
-                        <InputAdornment aria-label='submit search' position='end'>
-                            <IconButton type='submit' data-testid='search-button'>
-                                <Search className='!text-text' />
-                            </IconButton>
-                        </InputAdornment>
-                    }
-                />
-            </FormControl>
+            <TextInput
+                type='text'
+                name='q'
+                label='Search'
+                variant='outlined'
+                aria-label='search'
+                inputProps={{
+                    'data-testid': 'search-input',
+                }}
+                required
+                endAdornment={
+                    <InputAdornment aria-label='submit search' position='end'>
+                        <IconButton type='submit' data-testid='search-button'>
+                            <Search className='!text-text' />
+                        </IconButton>
+                    </InputAdornment>
+                }
+            />
         </Form>
     );
 };

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -14,7 +14,7 @@ interface TextInputProps {
      */
     id?: string;
     /**
-     * HTML input element type, defaults to text
+     * HTML input element type, defaults to `text`
      */
     type?: 'text' | 'username' | 'email' | 'password' | 'search' | 'url';
     /**
@@ -24,13 +24,13 @@ interface TextInputProps {
     /**
      * Label to display in the input field
      */
-    label?: string;
+    label: string;
     /**
      * HTML autocomplete attribute
      */
     autoComplete?: string;
     /**
-     * Controls variant of MUI Input component, defaults to filled
+     * Controls variant of MUI Input component, defaults to `filled`
      */
     variant?: 'filled' | 'outlined';
     /**
@@ -64,7 +64,7 @@ interface TextInputProps {
     /**
      * Provides an accessible label to the element
      */
-    'aria-label'?: string;
+    ariaLabel?: string;
     /**
      * Attributes applied to the input element
      */
@@ -82,41 +82,22 @@ const TextInput: React.FC<TextInputProps> = ({
     label,
     autoComplete,
     variant = 'filled',
-    color = 'secondary',
+    color = 'primary',
     value,
     error,
     required,
     onChange,
     onFocus,
     endAdornment,
-    'aria-label': ariaLabel,
+    ariaLabel,
     inputProps,
     sx,
 }) => {
-    const renderFilledInput = (
-        <>
-            <FilledInputMUI
-                id={id}
-                type={type}
-                name={name}
-                autoComplete={autoComplete}
-                color={color}
-                className='!text-text'
-                value={value}
-                error={error}
-                required={required}
-                onChange={onChange}
-                onFocus={onFocus}
-                endAdornment={endAdornment}
-                aria-label={ariaLabel}
-                inputProps={{ ...inputProps }}
-            />
-        </>
-    );
+    const InputVariant = variant === 'filled' ? FilledInputMUI : InputMUI;
 
     const renderInput = (
         <>
-            <InputMUI
+            <InputVariant
                 id={id}
                 type={type}
                 name={name}
@@ -140,7 +121,7 @@ const TextInput: React.FC<TextInputProps> = ({
             <InputLabelMUI htmlFor={id ? id : name} color={color} className='!text-text'>
                 {label}
             </InputLabelMUI>
-            {variant === 'filled' ? renderFilledInput : renderInput}
+            {renderInput}
         </FormControlMUI>
     );
 };

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,0 +1,148 @@
+import React, { ReactElement } from 'react';
+import {
+    FormControl as FormControlMUI,
+    InputLabel as InputLabelMUI,
+    Input as InputMUI,
+    FilledInput as FilledInputMUI,
+    SxProps,
+    Theme,
+} from '@mui/material';
+
+interface TextInputProps {
+    /**
+     * HTML element id
+     */
+    id?: string;
+    /**
+     * HTML input element type, defaults to text
+     */
+    type?: 'text' | 'username' | 'email' | 'password' | 'search' | 'url';
+    /**
+     * HTML element name
+     */
+    name?: string;
+    /**
+     * Label to display in the input field
+     */
+    label?: string;
+    /**
+     * HTML autocomplete attribute
+     */
+    autoComplete?: string;
+    /**
+     * Controls variant of MUI Input component, defaults to filled
+     */
+    variant?: 'filled' | 'outlined';
+    /**
+     * MUI color of button, defaults to `secondary`
+     */
+    color?: 'primary' | 'secondary' | 'success' | 'error' | 'info' | 'warning';
+    /**
+     * Value of controlled input
+     */
+    value?: string;
+    /**
+     * If true, the input will indicate an error
+     */
+    error?: boolean;
+    /**
+     * If true, the input element is required
+     */
+    required?: boolean;
+    /**
+     * Function to be run when input value changes
+     */
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    /**
+     * Function to set email error to false when input focused
+     */
+    onFocus?: () => void;
+    /**
+     * Icon to show in the input field
+     */
+    endAdornment?: ReactElement;
+    /**
+     * Provides an accessible label to the element
+     */
+    'aria-label'?: string;
+    /**
+     * Attributes applied to the input element
+     */
+    inputProps?: object;
+    /**
+     * MUI styling props to override default styling
+     */
+    sx?: SxProps<Theme>;
+}
+
+const TextInput: React.FC<TextInputProps> = ({
+    id,
+    type = 'text',
+    name,
+    label,
+    autoComplete,
+    variant = 'filled',
+    color = 'secondary',
+    value,
+    error,
+    required,
+    onChange,
+    onFocus,
+    endAdornment,
+    'aria-label': ariaLabel,
+    inputProps,
+    sx,
+}) => {
+    const renderFilledInput = (
+        <>
+            <FilledInputMUI
+                id={id}
+                type={type}
+                name={name}
+                autoComplete={autoComplete}
+                color={color}
+                className='!text-text'
+                value={value}
+                error={error}
+                required={required}
+                onChange={onChange}
+                onFocus={onFocus}
+                endAdornment={endAdornment}
+                aria-label={ariaLabel}
+                inputProps={{ ...inputProps }}
+            />
+        </>
+    );
+
+    const renderInput = (
+        <>
+            <InputMUI
+                id={id}
+                type={type}
+                name={name}
+                autoComplete={autoComplete}
+                color={color}
+                className='!text-text'
+                value={value}
+                error={error}
+                required={required}
+                onChange={onChange}
+                onFocus={onFocus}
+                endAdornment={endAdornment}
+                aria-label={ariaLabel}
+                inputProps={{ ...inputProps }}
+            />
+        </>
+    );
+
+    return (
+        <FormControlMUI sx={{ m: 0.5, ...sx }} variant='filled'>
+            <InputLabelMUI htmlFor={id ? id : name} color={color} className='!text-text'>
+                {label}
+            </InputLabelMUI>
+            {variant === 'filled' ? renderFilledInput : renderInput}
+        </FormControlMUI>
+    );
+};
+
+export default TextInput;

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,16 +1,9 @@
 import React, { useState } from 'react';
-import { Button, Snackbar } from '../../components';
+import { Button, Snackbar, TextInput } from '../../components';
 import { SUPABASE } from '../../helpers';
 import { useSessionContext } from '../../hooks';
 import { Link, Navigate } from 'react-router-dom';
-import {
-    InputAdornment,
-    FilledInput,
-    InputLabel,
-    FormControl,
-    IconButton,
-    Typography as Typ,
-} from '@mui/material';
+import { InputAdornment, IconButton, Typography as Typ } from '@mui/material';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 import Logger from '../../logger';
 import { SnackbarProps } from '../Snackbar';
@@ -103,51 +96,39 @@ const LoginForm: React.FC = (): JSX.Element => {
                 Login
             </Typ>
             <form onSubmit={signInWithEmail} className='flex flex-col' data-testid='login-form'>
-                <FormControl sx={{ m: 0.5 }} variant='filled'>
-                    <InputLabel htmlFor='email-input' color='secondary' className='!text-text'>
-                        Email
-                    </InputLabel>
-                    <FilledInput
-                        id='email-input'
-                        type='email'
-                        name='email'
-                        autoComplete='email'
-                        color='secondary'
-                        className='!text-text'
-                        value={email}
-                        error={emailError}
-                        onChange={(e) => setEmail(e.target.value)}
-                        onFocus={() => setEmailError(false)}
-                    />
-                </FormControl>
-                <FormControl sx={{ m: 0.5 }} variant='filled'>
-                    <InputLabel htmlFor='password-input' color='secondary' className='!text-text'>
-                        Password
-                    </InputLabel>
-                    <FilledInput
-                        id='password-input'
-                        name='password'
-                        type={isPasswordVisible ? 'text' : 'password'}
-                        autoComplete='new-password'
-                        value={password}
-                        error={passwordError}
-                        color='secondary'
-                        className='!text-text'
-                        onChange={(e) => setPassword(e.target.value)}
-                        onFocus={() => setPasswordError(false)}
-                        endAdornment={
-                            <InputAdornment position='end'>
-                                <IconButton
-                                    aria-label='toggle password visibility'
-                                    onClick={() => setIsPasswordVisible((prev) => !prev)}
-                                    edge='end'
-                                >
-                                    {isPasswordVisible ? <VisibilityOff /> : <Visibility />}
-                                </IconButton>
-                            </InputAdornment>
-                        }
-                    />
-                </FormControl>
+                <TextInput
+                    id='email-input'
+                    type='email'
+                    name='email'
+                    label='Email'
+                    autoComplete='email'
+                    value={email}
+                    error={emailError}
+                    onChange={(e) => setEmail(e.target.value)}
+                    onFocus={() => setEmailError(false)}
+                />
+                <TextInput
+                    id='password-input'
+                    name='password'
+                    type={isPasswordVisible ? 'text' : 'password'}
+                    label='Password'
+                    autoComplete='new-password'
+                    value={password}
+                    error={passwordError}
+                    onChange={(e) => setPassword(e.target.value)}
+                    onFocus={() => setPasswordError(false)}
+                    endAdornment={
+                        <InputAdornment position='end'>
+                            <IconButton
+                                aria-label='toggle password visibility'
+                                onClick={() => setIsPasswordVisible((prev) => !prev)}
+                                edge='end'
+                            >
+                                {isPasswordVisible ? <VisibilityOff /> : <Visibility />}
+                            </IconButton>
+                        </InputAdornment>
+                    }
+                />
                 <Button title='Submit' type='submit' loading={loading} />
             </form>
             <div className='mt-2'>

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -101,6 +101,7 @@ const LoginForm: React.FC = (): JSX.Element => {
                     type='email'
                     name='email'
                     label='Email'
+                    color='secondary'
                     autoComplete='email'
                     value={email}
                     error={emailError}
@@ -112,6 +113,7 @@ const LoginForm: React.FC = (): JSX.Element => {
                     name='password'
                     type={isPasswordVisible ? 'text' : 'password'}
                     label='Password'
+                    color='secondary'
                     autoComplete='new-password'
                     value={password}
                     error={passwordError}

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -182,6 +182,7 @@ const SignUpForm: React.FC = (): JSX.Element => {
                     type='email'
                     name='email'
                     label='Email'
+                    color='secondary'
                     autoComplete='email'
                     value={email}
                     error={emailError}
@@ -193,6 +194,7 @@ const SignUpForm: React.FC = (): JSX.Element => {
                     type='username'
                     name='username'
                     label='Username'
+                    color='secondary'
                     value={username}
                     error={usernameError}
                     onChange={(e) => setUsername(e.target.value)}
@@ -222,6 +224,7 @@ const SignUpForm: React.FC = (): JSX.Element => {
                     name='password'
                     type={isPasswordVisible ? 'text' : 'password'}
                     label='Password'
+                    color='secondary'
                     autoComplete='new-password'
                     value={password}
                     error={passwordError}
@@ -249,6 +252,7 @@ const SignUpForm: React.FC = (): JSX.Element => {
                     name='confirm-password'
                     type={isConfirmPasswordVisible ? 'text' : 'password'}
                     label='Confirm Password'
+                    color='secondary'
                     value={confirmPassword}
                     error={confirmPasswordError}
                     onChange={(e) => setConfirmPassword(e.target.value)}

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -1,11 +1,10 @@
 import React, { useState, useMemo } from 'react';
-import { Button, Snackbar } from '../../components';
+import { Button, Snackbar, TextInput } from '../../components';
 import { SUPABASE, COUNTRIES } from '../../helpers';
 import { useSessionContext } from '../../hooks';
 import { Link, Navigate } from 'react-router-dom';
 import {
     InputAdornment,
-    FilledInput,
     InputLabel,
     FormControl,
     IconButton,
@@ -178,39 +177,27 @@ const SignUpForm: React.FC = (): JSX.Element => {
                 Sign Up
             </Typ>
             <form onSubmit={signUpHandler} className='flex flex-col' data-testid='signup-form'>
-                <FormControl sx={{ m: 0.5 }} variant='filled'>
-                    <InputLabel htmlFor='email-input' color='secondary' className='!text-text'>
-                        Email
-                    </InputLabel>
-                    <FilledInput
-                        id='email-input'
-                        type='email'
-                        name='email'
-                        autoComplete='email'
-                        color='secondary'
-                        className='!text-text'
-                        value={email}
-                        error={emailError}
-                        onChange={(e) => setEmail(e.target.value)}
-                        onFocus={() => setEmailError(false)}
-                    />
-                </FormControl>
-                <FormControl sx={{ m: 0.5 }} variant='filled'>
-                    <InputLabel htmlFor='username-input' color='secondary' className='!text-text'>
-                        Username
-                    </InputLabel>
-                    <FilledInput
-                        id='username-input'
-                        type='username'
-                        name='username'
-                        color='secondary'
-                        className='!text-text'
-                        value={username}
-                        error={usernameError}
-                        onChange={(e) => setUsername(e.target.value)}
-                        onFocus={() => setUsernameError(false)}
-                    />
-                </FormControl>
+                <TextInput
+                    id='email-input'
+                    type='email'
+                    name='email'
+                    label='Email'
+                    autoComplete='email'
+                    value={email}
+                    error={emailError}
+                    onChange={(e) => setEmail(e.target.value)}
+                    onFocus={() => setEmailError(false)}
+                />
+                <TextInput
+                    id='username-input'
+                    type='username'
+                    name='username'
+                    label='Username'
+                    value={username}
+                    error={usernameError}
+                    onChange={(e) => setUsername(e.target.value)}
+                    onFocus={() => setUsernameError(false)}
+                />
                 <FormControl sx={{ m: 0.5 }} variant='filled'>
                     <InputLabel htmlFor='country-input' color='secondary' className='!text-text'>
                         Country
@@ -230,74 +217,58 @@ const SignUpForm: React.FC = (): JSX.Element => {
                         {DropDownItems}
                     </Select>
                 </FormControl>
-                <FormControl sx={{ m: 0.5 }} variant='filled'>
-                    <InputLabel htmlFor='password-input' color='secondary' className='!text-text'>
-                        Password
-                    </InputLabel>
-                    <FilledInput
-                        id='password-input'
-                        name='password'
-                        type={isPasswordVisible ? 'text' : 'password'}
-                        autoComplete='new-password'
-                        color='secondary'
-                        className='!text-text'
-                        value={password}
-                        error={passwordError}
-                        onChange={(e) => setPassword(e.target.value)}
-                        onFocus={() => setPasswordError(false)}
-                        endAdornment={
-                            <InputAdornment position='end'>
-                                <IconButton
-                                    aria-label='toggle password visibility'
-                                    onClick={() => togglePasswordVisibility(false)}
-                                    edge='end'
-                                    sx={{ backgroundColor: 'none' }}
-                                >
-                                    {isPasswordVisible ? (
-                                        <VisibilityOff className='!text-text' />
-                                    ) : (
-                                        <Visibility className='!text-text' />
-                                    )}
-                                </IconButton>
-                            </InputAdornment>
-                        }
-                    />
-                </FormControl>
-                <FormControl sx={{ m: 0.5 }} variant='filled'>
-                    <InputLabel
-                        htmlFor='confirm-password-input'
-                        color='secondary'
-                        className='!text-text'
-                    >
-                        Confirm Password
-                    </InputLabel>
-                    <FilledInput
-                        id='confirm-password-input'
-                        name='confirm-password'
-                        type={isConfirmPasswordVisible ? 'text' : 'password'}
-                        value={confirmPassword}
-                        error={confirmPasswordError}
-                        color='secondary'
-                        className='!text-text'
-                        onChange={(e) => setConfirmPassword(e.target.value)}
-                        onFocus={() => setConfirmPasswordError(false)}
-                        endAdornment={
-                            <InputAdornment position='end'>
-                                <IconButton
-                                    aria-label='toggle confirm password visibility'
-                                    onClick={() => togglePasswordVisibility(true)}
-                                    edge='end'
-                                >
-                                    {isConfirmPasswordVisible ? (
-                                        <VisibilityOff className='!text-text' />
-                                    ) : (
-                                        <Visibility className='!text-text' />
-                                    )}
-                                </IconButton>
-                            </InputAdornment>
-                        }
-                    />
-                </FormControl>
+                <TextInput
+                    id='password-input'
+                    name='password'
+                    type={isPasswordVisible ? 'text' : 'password'}
+                    label='Password'
+                    autoComplete='new-password'
+                    value={password}
+                    error={passwordError}
+                    onChange={(e) => setPassword(e.target.value)}
+                    onFocus={() => setPasswordError(false)}
+                    endAdornment={
+                        <InputAdornment position='end'>
+                            <IconButton
+                                aria-label='toggle password visibility'
+                                onClick={() => togglePasswordVisibility(false)}
+                                edge='end'
+                                sx={{ backgroundColor: 'none' }}
+                            >
+                                {isPasswordVisible ? (
+                                    <VisibilityOff className='!text-text' />
+                                ) : (
+                                    <Visibility className='!text-text' />
+                                )}
+                            </IconButton>
+                        </InputAdornment>
+                    }
+                />
+                <TextInput
+                    id='confirm-password-input'
+                    name='confirm-password'
+                    type={isConfirmPasswordVisible ? 'text' : 'password'}
+                    label='Confirm Password'
+                    value={confirmPassword}
+                    error={confirmPasswordError}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    onFocus={() => setConfirmPasswordError(false)}
+                    endAdornment={
+                        <InputAdornment position='end'>
+                            <IconButton
+                                aria-label='toggle confirm password visibility'
+                                onClick={() => togglePasswordVisibility(true)}
+                                edge='end'
+                            >
+                                {isConfirmPasswordVisible ? (
+                                    <VisibilityOff className='!text-text' />
+                                ) : (
+                                    <Visibility className='!text-text' />
+                                )}
+                            </IconButton>
+                        </InputAdornment>
+                    }
+                />
                 <Button title='Submit' type='submit' loading={loading} />
             </form>
             <div className='mt-2'>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,6 +16,7 @@ import EmptySearchResults from './EmptySearchResults';
 import IconButton from './IconButton';
 import Snackbar from './Snackbar';
 import Footer from './Footer';
+import TextInput from './TextInput';
 
 export {
     ShowCard,
@@ -33,6 +34,7 @@ export {
     IconButton,
     Snackbar,
     Footer,
+    TextInput,
 };
 export * from './loaders';
 export * from './modals';

--- a/src/components/modals/EditProfileModal.tsx
+++ b/src/components/modals/EditProfileModal.tsx
@@ -6,7 +6,6 @@ import {
 } from '../../supabase/profiles';
 import {
     Box,
-    FilledInput,
     FormControl,
     InputLabel,
     Modal,
@@ -19,6 +18,7 @@ import { Profile, Session } from '../../types';
 import Button from '../Button';
 import { COUNTRIES } from '../../helpers';
 import Snackbar, { SnackbarProps } from '../Snackbar';
+import TextInput from '../TextInput';
 
 interface EditProfileModalProps {
     session: Session;
@@ -168,23 +168,19 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
                 >
                     <div className='flex flex-col items-center bg-background p-4 rounded-md'>
                         <Typ variant='h5'>Edit Profile</Typ>
-                        <FormControl sx={{ m: 0.5 }} variant='filled'>
-                            <InputLabel htmlFor='username' color='secondary' className='!text-text'>
-                                Change Username
-                            </InputLabel>
-                            <FilledInput
-                                name='username'
-                                value={username}
-                                onChange={(e) => {
-                                    setUsername(e.target.value);
-                                }}
-                                error={usernameError}
-                                onFocus={() => setUsernameError(false)}
-                                inputProps={{ minLength: 3 }}
-                                sx={{ m: 0.5, width: 210 }}
-                                autoComplete='username'
-                            />
-                        </FormControl>
+                        <TextInput
+                            name='username'
+                            value={username}
+                            label='Change Username'
+                            autoComplete='username'
+                            error={usernameError}
+                            onChange={(e) => {
+                                setUsername(e.target.value);
+                            }}
+                            onFocus={() => setUsernameError(false)}
+                            inputProps={{ minLength: 3 }}
+                            sx={{ m: 0.5, width: 210 }}
+                        />
                         <Typ>Current Username: {profile?.username}</Typ>
                         <Button
                             title='Change Username'

--- a/src/components/modals/EditProfileModal.tsx
+++ b/src/components/modals/EditProfileModal.tsx
@@ -172,6 +172,7 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
                             name='username'
                             value={username}
                             label='Change Username'
+                            color='secondary'
                             autoComplete='username'
                             error={usernameError}
                             onChange={(e) => {

--- a/src/stories/components/TextInput.stories.ts
+++ b/src/stories/components/TextInput.stories.ts
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TextInput } from '../../components';
+import { withRouter } from 'storybook-addon-react-router-v6';
+
+const meta = {
+    title: 'Components/Text Input',
+    component: TextInput,
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'centered',
+    },
+    decorators: [withRouter],
+} satisfies Meta<typeof TextInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+    args: {
+        label: 'Email',
+    },
+};
+
+export const Search: Story = {
+    args: {
+        label: 'Search',
+        variant: 'outlined',
+    },
+};


### PR DESCRIPTION
I've created a custom text component  to replace repetitive input code in the `LoginForm`, `SignupForm`, `EditProfileModal`, and `SearchInput` components.  All props originally passed to the input components can be passed to the new `TextInput` component except for `className` which I noticed was identical across all instances of the inputs and which I've just passed as a prop to the internal components of `TextInput`.

I also noticed that `SearchInput` was originally making use of the `Input` MUI component whereas all the other text inputs were using `FilledInput`.  The `TextInput` manages this by receiving a `variant` prop which can receive either 'filled' or 'outlined'.

There are two instances of inputs on the `SignupForm` and `EditProfileModal` that are making use of the `Select` MUI component. I have not modified this as I would like to make an additional custom component called `SelectInput` to replace these.

One last point is that the password and search fields have an `endAdornment` prop which receives a React component for a value. I have handled this by having the `TextInput` component receive that same prop which is then being handled accordingly. I have ideas of making a custom `EndAdornment` component but I would like your ideas on this first.

Looking forward to hearing your feedback! This is my first solo contribution to this project and my first contribution to open source development outside of a bootcamp.

## Screenshot

<img width="1024" alt="image" src="https://github.com/Thenlie/Streamability/assets/41388783/214a60af-986d-4eb8-9ec1-943776297b61">
