### PR TITLE
Country validation

### DIFF
--- a/src/components/modals/EditProfileModal.tsx
+++ b/src/components/modals/EditProfileModal.tsx
@@ -16,7 +16,7 @@ import {
 import { Close, Edit, Language, NoAdultContent } from '@mui/icons-material';
 import { Profile, Session } from '../../types';
 import Button from '../Button';
-import { COUNTRIES } from '../../helpers';
+import { COUNTRIES, validateCountry } from '../../helpers';
 import Snackbar, { SnackbarProps } from '../Snackbar';
 import TextInput from '../TextInput';
 
@@ -109,7 +109,7 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
     };
 
     const changeCountry = async () => {
-        if (session && country) {
+        if (session && country && validateCountry(country)) {
             setCountryLoading(true);
             const data = await setProfileCountry(session.user.id, country);
             setProfile(data);
@@ -127,7 +127,7 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
                 isOpen: true,
                 severity: 'error',
                 message: country
-                    ? 'Error updating country. Please check your network connection and try again.'
+                    ? 'Please select a valid country from the provided list.'
                     : 'Please select a country.',
                 hash: country,
             });

--- a/src/helpers/__tests__/validation.test.ts
+++ b/src/helpers/__tests__/validation.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { validateCountryCode } from '../validationUtils';
+
+describe('validateCountryCode', () => {
+    it('properly validates valid country codes', () => {
+        expect(validateCountryCode('US')).toBe(true);
+        expect(validateCountryCode('CA')).toBe(true);
+        expect(validateCountryCode('FR')).toBe(true);
+        expect(validateCountryCode('RU')).toBe(true);
+    });
+    it('properly validates invalid country codes', () => {
+        expect(validateCountryCode('ZZZ')).toBe(false);
+        expect(validateCountryCode('ZF')).toBe(false);
+        expect(validateCountryCode('11')).toBe(false);
+        expect(validateCountryCode('AA')).toBe(false);
+    });
+});

--- a/src/helpers/__tests__/validation.test.ts
+++ b/src/helpers/__tests__/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { validateCountryCode } from '../validationUtils';
+import { validateCountry, validateCountryCode } from '../validationUtils';
 
 describe('validateCountryCode', () => {
     it('properly validates valid country codes', () => {
@@ -13,5 +13,20 @@ describe('validateCountryCode', () => {
         expect(validateCountryCode('ZF')).toBe(false);
         expect(validateCountryCode('11')).toBe(false);
         expect(validateCountryCode('AA')).toBe(false);
+    });
+});
+
+describe('validateCountryC', () => {
+    it('properly validates valid countries', () => {
+        expect(validateCountry('United States of America')).toBe(true);
+        expect(validateCountry('Canada')).toBe(true);
+        expect(validateCountry('France')).toBe(true);
+        expect(validateCountry('Russia')).toBe(true);
+    });
+    it('properly validates invalid countries', () => {
+        expect(validateCountry('USA')).toBe(false);
+        expect(validateCountry('UK')).toBe(false);
+        expect(validateCountry('Russsia')).toBe(false);
+        expect(validateCountry('invalid')).toBe(false);
     });
 });

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -7,3 +7,4 @@ export * from './showFilterUtils';
 export * from './showSortUtils';
 export * from './stringFormatUtils';
 export * from './supabaseClient';
+export * from './validationUtils';

--- a/src/helpers/validationUtils.ts
+++ b/src/helpers/validationUtils.ts
@@ -1,0 +1,14 @@
+import { COUNTRIES } from './constants';
+
+/**
+ * Returns `true` when the provided country code is a valid
+ * and supported code, otherwise returns `false`.
+ * @param country | 2 digit country code
+ * @returns {boolean}
+ */
+const validateCountryCode = (country: string): boolean => {
+    if (country.length !== 2) return false;
+    return !!COUNTRIES.find((c) => c.abbrev === country);
+};
+
+export { validateCountryCode };

--- a/src/helpers/validationUtils.ts
+++ b/src/helpers/validationUtils.ts
@@ -11,4 +11,14 @@ const validateCountryCode = (country: string): boolean => {
     return !!COUNTRIES.find((c) => c.abbrev === country);
 };
 
-export { validateCountryCode };
+/**
+ * Returns `true` when the provided country is valid
+ * and supported, otherwise returns `false`.
+ * @param country | country name
+ * @returns {boolean}
+ */
+const validateCountry = (country: string): boolean => {
+    return !!COUNTRIES.find((c) => c.country === country);
+};
+
+export { validateCountryCode, validateCountry };

--- a/src/screens/auth/SignUpScreen.tsx
+++ b/src/screens/auth/SignUpScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { Button, Snackbar, TextInput } from '../../components';
-import { SUPABASE, COUNTRIES } from '../../helpers';
+import { SUPABASE, COUNTRIES, validateCountry } from '../../helpers';
 import { useSessionContext } from '../../hooks';
 import { Link, Navigate } from 'react-router-dom';
 import {
@@ -107,6 +107,14 @@ const SignUpScreen: React.FC = () => {
         if (!email.match(/^(\w+|\d+)@(\w+|\d+)\.(\w+|\d+)/gm)) {
             showError('Must provide valid email');
             if (!email) setEmailError(true);
+            setLoading(false);
+            return;
+        }
+
+        // Ensure country is valid
+        if (!validateCountry(country)) {
+            showError('Must select a valid country');
+            setCountryError(true);
             setLoading(false);
             return;
         }


### PR DESCRIPTION
Added methods to validate country names and country codes. Implemented these validations on signup and profile edit. These shouldn't ever fail as we are using a drop down, but it is possible if a user edits the client side code.

Closes #587 