### PR TITLE
Refactor Carousel Loading

### DIFF
--- a/src/components/ShowCarousel.tsx
+++ b/src/components/ShowCarousel.tsx
@@ -14,6 +14,10 @@ interface ShowCarouselProps {
      */
     data: ShowData[] | null;
     /**
+     * If data being passed in is still loading
+     */
+    dataLoading?: boolean;
+    /**
      * Number of ShowCards to display in 1 step.
      * If `undefined` this number will be based on screen size
      */
@@ -95,6 +99,7 @@ const CarouselChildren: React.FC<{
  */
 const ShowCarousel: React.FC<ShowCarouselProps> = ({
     data,
+    dataLoading = false,
     size,
     fallbackText,
     ...rest
@@ -155,7 +160,7 @@ const ShowCarousel: React.FC<ShowCarouselProps> = ({
         return arr;
     };
 
-    if (loading) {
+    if (loading || dataLoading) {
         return (
             <section className='pt-12'>
                 <div className='flex justify-center' style={{ width: carouselWidth }}>

--- a/src/components/loaders/ShowCarouselLoader.tsx
+++ b/src/components/loaders/ShowCarouselLoader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ShowCardLoader from './ShowCardLoader';
+import ShowPosterLoader from './ShowPosterLoader';
 
 interface ShowCarouselLoaderProps {
     /**
@@ -19,7 +19,7 @@ const ShowCarouselLoader: React.FC<ShowCarouselLoaderProps> = ({ count }): JSX.E
         <div className='m-3 flex justify-center'>
             {[...Array(count)].map((x, i) => (
                 <div key={i} className='overflow-x-hidden'>
-                    <ShowCardLoader count={1} />
+                    <ShowPosterLoader count={1} />
                 </div>
             ))}
         </div>

--- a/src/hooks/__tests__/useGetProfileArray.test.ts
+++ b/src/hooks/__tests__/useGetProfileArray.test.ts
@@ -49,7 +49,7 @@ describe('useGetProfileArray', () => {
         const { result } = renderHook(({ whichCol }) => useGetProfileArray(whichCol), {
             initialProps: { whichCol: WHICH_COL[0] },
         });
-        await waitFor(() => expect(result.current).toBe(null));
+        await waitFor(() => expect(result.current.data).toBe(null));
     });
     it('Returns show array when profile array contains data', async () => {
         vi.mocked(getMovieDetails).mockResolvedValue(SHOW_DATA);
@@ -65,8 +65,8 @@ describe('useGetProfileArray', () => {
         const { result } = renderHook(({ whichCol }) => useGetProfileArray(whichCol), {
             initialProps: { whichCol: WHICH_COL[0] },
         });
-        await waitFor(() => expect(result.current?.[0].id).toBe(1726));
-        await waitFor(() => expect(result.current?.[0].title).toBe('Iron Man'));
-        await waitFor(() => expect(result.current?.[0].vote_average).toBe(7.631));
+        await waitFor(() => expect(result.current.data?.[0].id).toBe(1726));
+        await waitFor(() => expect(result.current.data?.[0].title).toBe('Iron Man'));
+        await waitFor(() => expect(result.current.data?.[0].vote_average).toBe(7.631));
     });
 });

--- a/src/hooks/useGetProfileArray.ts
+++ b/src/hooks/useGetProfileArray.ts
@@ -10,10 +10,13 @@ import { useProfileContext, useSessionContext } from './context';
  * @param whichCol | The profile array to get
  * @returns {ShowData[] | null}
  */
-const useGetProfileArray = (whichCol: ProfileArrayCols): ShowData[] | null => {
+const useGetProfileArray = (
+    whichCol: ProfileArrayCols
+): { data: ShowData[] | null; loading: boolean } => {
     const { session } = useSessionContext();
     const { profile } = useProfileContext();
     const [data, setData] = useState<ShowData[] | null>(null);
+    const [loading, setLoading] = useState(true);
 
     useEffect(() => {
         const handler = async () => {
@@ -33,9 +36,10 @@ const useGetProfileArray = (whichCol: ProfileArrayCols): ShowData[] | null => {
             setData(arr);
         };
         handler();
+        setLoading(false);
     }, [session, profile]);
 
-    return data;
+    return { data, loading };
 };
 
 export default useGetProfileArray;

--- a/src/screens/FeaturedSearchScreen.tsx
+++ b/src/screens/FeaturedSearchScreen.tsx
@@ -7,7 +7,7 @@ import { useTrendingShows } from '../hooks';
  * a search input, and trending shows in a carousel.
  */
 const FeaturedSearchScreen: React.FC = () => {
-    const { trendingShows } = useTrendingShows('release');
+    const { trendingShows, loading } = useTrendingShows('release');
 
     return (
         <div className='flex-1 flex flex-col w-full'>
@@ -18,7 +18,7 @@ const FeaturedSearchScreen: React.FC = () => {
                 renderLogo
             />
             <div className='my-12 mx-auto'>
-                <ShowCarousel data={trendingShows} />
+                <ShowCarousel data={trendingShows} dataLoading={loading} />
             </div>
         </div>
     );

--- a/src/screens/dashboard/DashboardGalleryScreen.tsx
+++ b/src/screens/dashboard/DashboardGalleryScreen.tsx
@@ -21,7 +21,7 @@ const DashboardGalleryScreen: React.FC = () => {
     const profileActions = useProfileActions(profile, setProfile);
     const navigate = useNavigate();
     const path: ProfileArrayCols = useLoaderData() as ProfileArrayCols;
-    const data = useGetProfileArray(path);
+    const { data } = useGetProfileArray(path);
 
     // TODO: If profile does not return after a few seconds,
     // we should assume the user is not logged in and redirect to an auth page

--- a/src/screens/dashboard/DashboardScreen.tsx
+++ b/src/screens/dashboard/DashboardScreen.tsx
@@ -19,6 +19,10 @@ interface DashboardCarouselProps {
      */
     data: ShowData[] | null;
     /**
+     * If data being passed in is still loading
+     */
+    dataLoading?: boolean;
+    /**
      * Which profile array the data is coming from
      */
     whichCol: ProfileArrayCols;
@@ -50,6 +54,7 @@ interface DashboardCarouselProps {
  */
 export const DashboardCarousel: React.FC<DashboardCarouselProps> = ({
     data,
+    dataLoading = false,
     whichCol,
     label,
     fallbackText,
@@ -84,6 +89,7 @@ export const DashboardCarousel: React.FC<DashboardCarouselProps> = ({
             </div>
             <ShowCarousel
                 data={data}
+                dataLoading={dataLoading}
                 fallbackText={fallbackText}
                 profile={profile}
                 profileActions={profileActions}
@@ -111,9 +117,9 @@ export const DashboardCarousel: React.FC<DashboardCarouselProps> = ({
 const DashboardScreen: React.FC = () => {
     const { session, setSession } = useSessionContext();
     const { profile, setProfile } = useProfileContext();
-    const queue = useGetProfileArray('queue');
-    const favorites = useGetProfileArray('favorites');
-    const watched = useGetProfileArray('watched');
+    const { data: queue, loading: queueLoading } = useGetProfileArray('queue');
+    const { data: favorites, loading: favoritesLoading } = useGetProfileArray('favorites');
+    const { data: watched, loading: watchedLoading } = useGetProfileArray('watched');
     const [logoutLoading, setLogoutLoading] = useState(false);
     const [deleteLoading, setDeleteLoading] = useState(false);
     const navigate = useNavigate();
@@ -217,6 +223,7 @@ const DashboardScreen: React.FC = () => {
                 </div>
                 <DashboardCarousel
                     data={queue}
+                    dataLoading={queueLoading}
                     whichCol='queue'
                     label='Watch Queue'
                     fallbackText={queueFallbackText}
@@ -225,6 +232,7 @@ const DashboardScreen: React.FC = () => {
                 />
                 <DashboardCarousel
                     data={favorites}
+                    dataLoading={favoritesLoading}
                     whichCol='favorites'
                     label='Favorites'
                     fallbackText={favoritesFallbackText}
@@ -233,6 +241,7 @@ const DashboardScreen: React.FC = () => {
                 />
                 <DashboardCarousel
                     data={watched}
+                    dataLoading={watchedLoading}
                     whichCol='watched'
                     label='Watched List'
                     fallbackText={watchedFallbackText}

--- a/src/screens/search_results/EmptySearchResults.tsx
+++ b/src/screens/search_results/EmptySearchResults.tsx
@@ -23,7 +23,7 @@ interface EmptySearchResultsProps {
  */
 const EmptySearchResults: React.FC<EmptySearchResultsProps> = ({ query, viewState }) => {
     const navigate = useNavigate();
-    const { trendingShows } = useTrendingShows();
+    const { trendingShows, loading } = useTrendingShows();
 
     return (
         <>
@@ -54,7 +54,7 @@ const EmptySearchResults: React.FC<EmptySearchResultsProps> = ({ query, viewStat
                             These popular shows might interest you:
                         </Typ>
                         <div className='flex w-full justify-center items-center pb-6'>
-                            <ShowCarousel data={trendingShows} />
+                            <ShowCarousel data={trendingShows} dataLoading={loading} />
                         </div>
                     </>
                 )}


### PR DESCRIPTION
Now accepts an optional `dataLoading` prop to internally handing rendering loader. Closes #624 