### PR TITLE
fix dashboard empty gallery padding

### DIFF
--- a/src/screens/dashboard/DashboardEmptyGallery.tsx
+++ b/src/screens/dashboard/DashboardEmptyGallery.tsx
@@ -14,7 +14,7 @@ const DashboardEmptyGallery: React.FC<DashboardEmptyGalleryProps> = ({ title }) 
             <div className='flex justify-center w-full'>
                 <img src='/images/resting.svg' width={500}></img>
             </div>
-            <Typ variant='h5'>{`Your ${title} is empty!`}</Typ>
+            <Typ variant='h5' sx={{ marginTop: 4 }}>{`Your ${title} is empty!`}</Typ>
             <Typ variant='body1'>{`Add shows to you ${title} to view them here.`}</Typ>
         </div>
     );

--- a/src/screens/dashboard/DashboardGalleryScreen.tsx
+++ b/src/screens/dashboard/DashboardGalleryScreen.tsx
@@ -44,7 +44,7 @@ const DashboardGalleryScreen: React.FC = () => {
 
     return (
         <div className='m-4'>
-            <Typ variant='h5'>{`${profile.username}'s ${getTitle(path)}`}</Typ>
+            <Typ variant='h5' sx={{ padding: 2 }}>{`${profile.username}'s ${getTitle(path)}`}</Typ>
             <Button
                 title='Dashboard'
                 StartIcon={ArrowBack}


### PR DESCRIPTION
## Description

<!-- Provide a description of the changes made -->
Add spacing around empty dashboard gallery header

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created

## Screenshots

**Before**
![image](https://github.com/Thenlie/Streamability/assets/41388783/f343b1a5-6f99-4161-91e4-5ab203972ee1)

**After**
![image](https://github.com/Thenlie/Streamability/assets/41388783/6da83715-1db3-4bf9-9bdd-3f87c91df2aa)

Closes #657 
