### PR TITLE
Notify users of offline state

### DIFF
--- a/src/components/OfflineSnackbar.tsx
+++ b/src/components/OfflineSnackbar.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Snackbar from './Snackbar';
+import { useNetworkStatus } from '../hooks';
+
+/**
+ * Snackbar that displays when the user is not connected to the internet.
+ * Is automatically removed when connection is re-established
+ */
+const OfflineSnackbar: React.FC = () => {
+    const isOnline = useNetworkStatus();
+
+    return (
+        <Snackbar
+            isOpen={!isOnline}
+            isStatic
+            severity='info'
+            message='You appear to be offline. Please check your network connection to make the most of Streamability'
+        />
+    );
+};
+
+export default OfflineSnackbar;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,6 +14,7 @@ import Button from './Button';
 import EmptySearchResults from '../screens/search_results/EmptySearchResults';
 import IconButton from './IconButton';
 import Snackbar from './Snackbar';
+import OfflineSnackbar from './OfflineSnackbar';
 import Footer from './Footer';
 import TextInput from './TextInput';
 import Banner from './Banner';
@@ -31,6 +32,7 @@ export {
     EmptySearchResults,
     IconButton,
     Snackbar,
+    OfflineSnackbar,
     Footer,
     TextInput,
     Banner,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,6 +5,7 @@ import useIsInProfileArray from './useIsInProfileArray';
 import useDebounceValue from './useDebounceValue';
 import useTrendingShows from './useTrendingShows';
 import useGetProfileArray from './useGetProfileArray';
+import useNetworkStatus from './useNetworkStatus';
 
 export {
     useProfileContext,
@@ -15,4 +16,5 @@ export {
     useDebounceValue,
     useTrendingShows,
     useGetProfileArray,
+    useNetworkStatus,
 };

--- a/src/hooks/useNetworkStatus.ts
+++ b/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Custom hook that returns the browsers network status
+ */
+const useNetworkStatus = (): boolean => {
+    const [online, setOnline] = useState(navigator.onLine);
+
+    useEffect(() => {
+        window.addEventListener('online', () => setOnline(true));
+        window.addEventListener('offline', () => setOnline(false));
+
+        return () => {
+            window.removeEventListener('online', () => setOnline(true));
+            window.removeEventListener('offline', () => setOnline(false));
+        };
+    }, []);
+
+    return online;
+};
+
+export default useNetworkStatus;

--- a/src/hooks/useTrendingShows.ts
+++ b/src/hooks/useTrendingShows.ts
@@ -40,7 +40,6 @@ const useTrendingShows = (sortBy: 'rating' | 'release' | 'alpha' = 'rating') => 
                     setTrending(sortShowsByReleaseDateDesc(shows));
                     break;
                 case 'alpha':
-                    // console.log(3, shows, sortShowsAlphaAsc(shows));
                     setTrending(sortShowsAlphaAsc(shows));
                     break;
             }

--- a/src/screens/DiscoverScreen.tsx
+++ b/src/screens/DiscoverScreen.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
-import { useTrendingShows } from '../hooks';
+import { useNetworkStatus, useTrendingShows } from '../hooks';
 import { Typography as Typ } from '@mui/material';
-import { ShowCarousel, Banner } from '../components';
+import { ShowCarousel, Banner, Snackbar } from '../components';
 import { ShowData, DiscoverMovie, DiscoverTv } from '../types/tmdb';
 import { getDiscoverMovies, getDiscoverTv } from '../helpers';
 /**
@@ -10,6 +10,7 @@ import { getDiscoverMovies, getDiscoverTv } from '../helpers';
  */
 const DiscoverScreen: React.FC = () => {
     const { trendingShows, loading } = useTrendingShows('alpha');
+    const isOnline = useNetworkStatus();
     const [highestRated, setHighestRated] = useState<ShowData[] | null>(null);
     const [newlyAdded, setNewlyAdded] = useState<ShowData[] | null>(null);
     const [actionAdventure, setActionAdventure] = useState<ShowData[] | null>(null);
@@ -228,6 +229,12 @@ const DiscoverScreen: React.FC = () => {
                     <ShowCarousel data={popularHulu} dataLoading={popularHuluLoading} />
                 </div>
             </div>
+            <Snackbar
+                isOpen={!isOnline}
+                isStatic
+                severity='info'
+                message='You appear to be offline. Please check your network connection to make the most of Streamability'
+            />
         </div>
     );
 };

--- a/src/screens/DiscoverScreen.tsx
+++ b/src/screens/DiscoverScreen.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
-import { useNetworkStatus, useTrendingShows } from '../hooks';
+import { useTrendingShows } from '../hooks';
 import { Typography as Typ } from '@mui/material';
-import { ShowCarousel, Banner, Snackbar } from '../components';
+import { ShowCarousel, Banner, OfflineSnackbar } from '../components';
 import { ShowData, DiscoverMovie, DiscoverTv } from '../types/tmdb';
 import { getDiscoverMovies, getDiscoverTv } from '../helpers';
 /**
@@ -10,7 +10,6 @@ import { getDiscoverMovies, getDiscoverTv } from '../helpers';
  */
 const DiscoverScreen: React.FC = () => {
     const { trendingShows, loading } = useTrendingShows('alpha');
-    const isOnline = useNetworkStatus();
     const [highestRated, setHighestRated] = useState<ShowData[] | null>(null);
     const [newlyAdded, setNewlyAdded] = useState<ShowData[] | null>(null);
     const [actionAdventure, setActionAdventure] = useState<ShowData[] | null>(null);
@@ -229,12 +228,7 @@ const DiscoverScreen: React.FC = () => {
                     <ShowCarousel data={popularHulu} dataLoading={popularHuluLoading} />
                 </div>
             </div>
-            <Snackbar
-                isOpen={!isOnline}
-                isStatic
-                severity='info'
-                message='You appear to be offline. Please check your network connection to make the most of Streamability'
-            />
+            <OfflineSnackbar />
         </div>
     );
 };

--- a/src/screens/FeaturedSearchScreen.tsx
+++ b/src/screens/FeaturedSearchScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { ShowCarousel, Banner } from '../components';
-import { useTrendingShows } from '../hooks';
+import { ShowCarousel, Banner, Snackbar } from '../components';
+import { useTrendingShows, useNetworkStatus } from '../hooks';
 
 /**
  * The landing page of the application which shows a show banner,
@@ -8,6 +8,7 @@ import { useTrendingShows } from '../hooks';
  */
 const FeaturedSearchScreen: React.FC = () => {
     const { trendingShows, loading } = useTrendingShows('release');
+    const isOnline = useNetworkStatus();
 
     return (
         <div className='flex-1 flex flex-col w-full'>
@@ -20,6 +21,12 @@ const FeaturedSearchScreen: React.FC = () => {
             <div className='my-12 mx-auto'>
                 <ShowCarousel data={trendingShows} dataLoading={loading} />
             </div>
+            <Snackbar
+                isOpen={!isOnline}
+                isStatic
+                severity='info'
+                message='You appear to be offline. Please check your network connection to make the most of Streamability'
+            />
         </div>
     );
 };

--- a/src/screens/FeaturedSearchScreen.tsx
+++ b/src/screens/FeaturedSearchScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { ShowCarousel, Banner, Snackbar } from '../components';
-import { useTrendingShows, useNetworkStatus } from '../hooks';
+import { ShowCarousel, Banner, OfflineSnackbar } from '../components';
+import { useTrendingShows } from '../hooks';
 
 /**
  * The landing page of the application which shows a show banner,
@@ -8,7 +8,6 @@ import { useTrendingShows, useNetworkStatus } from '../hooks';
  */
 const FeaturedSearchScreen: React.FC = () => {
     const { trendingShows, loading } = useTrendingShows('release');
-    const isOnline = useNetworkStatus();
 
     return (
         <div className='flex-1 flex flex-col w-full'>
@@ -21,12 +20,7 @@ const FeaturedSearchScreen: React.FC = () => {
             <div className='my-12 mx-auto'>
                 <ShowCarousel data={trendingShows} dataLoading={loading} />
             </div>
-            <Snackbar
-                isOpen={!isOnline}
-                isStatic
-                severity='info'
-                message='You appear to be offline. Please check your network connection to make the most of Streamability'
-            />
+            <OfflineSnackbar />
         </div>
     );
 };

--- a/src/screens/PageNotFoundScreen.tsx
+++ b/src/screens/PageNotFoundScreen.tsx
@@ -5,6 +5,7 @@ import Logger from '../logger';
 import React from 'react';
 import { ArrowBack, Home } from '@mui/icons-material';
 import { Typography as Typ } from '@mui/material';
+import { useNetworkStatus } from '../hooks';
 
 const LOG = new Logger('PageNotFoundScreen');
 
@@ -13,6 +14,7 @@ const LOG = new Logger('PageNotFoundScreen');
  */
 const PageNotFoundScreen: React.FC = (): JSX.Element => {
     const navigate = useNavigate();
+    const isOnline = useNetworkStatus();
 
     /**
      * This hook returns anything thrown during an
@@ -36,6 +38,12 @@ const PageNotFoundScreen: React.FC = (): JSX.Element => {
             {error.statusText && (
                 <Snackbar isOpen isStatic severity='error' message={error.statusText} />
             )}
+            <Snackbar
+                isOpen={!isOnline}
+                isStatic
+                severity='info'
+                message='You appear to be offline. Please check your network connection to make the most of Streamability'
+            />
         </div>
     );
 };

--- a/src/screens/PageNotFoundScreen.tsx
+++ b/src/screens/PageNotFoundScreen.tsx
@@ -1,11 +1,10 @@
 import { ErrorResponse } from '@remix-run/router';
 import { useNavigate, useRouteError } from 'react-router-dom';
-import { Button, Snackbar } from '../components';
+import { Button, OfflineSnackbar, Snackbar } from '../components';
 import Logger from '../logger';
 import React from 'react';
 import { ArrowBack, Home } from '@mui/icons-material';
 import { Typography as Typ } from '@mui/material';
-import { useNetworkStatus } from '../hooks';
 
 const LOG = new Logger('PageNotFoundScreen');
 
@@ -14,7 +13,6 @@ const LOG = new Logger('PageNotFoundScreen');
  */
 const PageNotFoundScreen: React.FC = (): JSX.Element => {
     const navigate = useNavigate();
-    const isOnline = useNetworkStatus();
 
     /**
      * This hook returns anything thrown during an
@@ -38,12 +36,7 @@ const PageNotFoundScreen: React.FC = (): JSX.Element => {
             {error.statusText && (
                 <Snackbar isOpen isStatic severity='error' message={error.statusText} />
             )}
-            <Snackbar
-                isOpen={!isOnline}
-                isStatic
-                severity='info'
-                message='You appear to be offline. Please check your network connection to make the most of Streamability'
-            />
+            <OfflineSnackbar />
         </div>
     );
 };

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -9,10 +9,15 @@ import {
     getTvRecommendations,
 } from '../helpers';
 import { ShowData } from '../types';
-import { Providers, ShowCarousel, Rating, Button } from '../components';
+import { Providers, ShowCarousel, Rating, Button, Snackbar } from '../components';
 import { Tooltip, Typography as Typ } from '@mui/material';
 import { ShowDetailsLoader } from './loaders';
-import { useProfileContext, useIsInProfileArray, useProfileActions } from '../hooks';
+import {
+    useProfileContext,
+    useIsInProfileArray,
+    useProfileActions,
+    useNetworkStatus,
+} from '../hooks';
 import {
     AddToQueue,
     Cancel,
@@ -121,6 +126,7 @@ const ShowDetailsScreen: React.FC = () => {
     const showId = parseInt(location.pathname.split('/')[3]);
     const showType = location.pathname.split('/')[2];
     const { profile } = useProfileContext();
+    const isOnline = useNetworkStatus();
     const [details, setDetails] = useState<ShowData>(
         location.state ? location.state.details : null
     );
@@ -215,6 +221,12 @@ const ShowDetailsScreen: React.FC = () => {
                     profile={profile}
                 />
             </section>
+            <Snackbar
+                isOpen={!isOnline}
+                isStatic
+                severity='info'
+                message='You appear to be offline. Please check your network connection to make the most of Streamability'
+            />
         </>
     );
 };

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -9,15 +9,10 @@ import {
     getTvRecommendations,
 } from '../helpers';
 import { ShowData } from '../types';
-import { Providers, ShowCarousel, Rating, Button, Snackbar } from '../components';
+import { Providers, ShowCarousel, Rating, Button, OfflineSnackbar } from '../components';
 import { Tooltip, Typography as Typ } from '@mui/material';
 import { ShowDetailsLoader } from './loaders';
-import {
-    useProfileContext,
-    useIsInProfileArray,
-    useProfileActions,
-    useNetworkStatus,
-} from '../hooks';
+import { useProfileContext, useIsInProfileArray, useProfileActions } from '../hooks';
 import {
     AddToQueue,
     Cancel,
@@ -126,7 +121,6 @@ const ShowDetailsScreen: React.FC = () => {
     const showId = parseInt(location.pathname.split('/')[3]);
     const showType = location.pathname.split('/')[2];
     const { profile } = useProfileContext();
-    const isOnline = useNetworkStatus();
     const [details, setDetails] = useState<ShowData>(
         location.state ? location.state.details : null
     );
@@ -221,12 +215,7 @@ const ShowDetailsScreen: React.FC = () => {
                     profile={profile}
                 />
             </section>
-            <Snackbar
-                isOpen={!isOnline}
-                isStatic
-                severity='info'
-                message='You appear to be offline. Please check your network connection to make the most of Streamability'
-            />
+            <OfflineSnackbar />
         </>
     );
 };

--- a/src/screens/auth/AuthLayout.tsx
+++ b/src/screens/auth/AuthLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom';
-import { useSessionContext } from '../../hooks';
+import { useNetworkStatus, useSessionContext } from '../../hooks';
 import React from 'react';
+import { Snackbar } from '../../components';
 
 /**
  * Wrapper for all authentication components
@@ -8,10 +9,17 @@ import React from 'react';
  */
 const AuthLayout: React.FC = () => {
     const { session } = useSessionContext();
+    const isOnline = useNetworkStatus();
 
     return (
         <>
             <Outlet context={{ session }} />
+            <Snackbar
+                isOpen={!isOnline}
+                isStatic
+                severity='info'
+                message='You appear to be offline. Please check your network connection to make the most of Streamability'
+            />
         </>
     );
 };

--- a/src/screens/auth/AuthLayout.tsx
+++ b/src/screens/auth/AuthLayout.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from 'react-router-dom';
-import { useNetworkStatus, useSessionContext } from '../../hooks';
+import { useSessionContext } from '../../hooks';
 import React from 'react';
-import { Snackbar } from '../../components';
+import { OfflineSnackbar } from '../../components';
 
 /**
  * Wrapper for all authentication components
@@ -9,17 +9,11 @@ import { Snackbar } from '../../components';
  */
 const AuthLayout: React.FC = () => {
     const { session } = useSessionContext();
-    const isOnline = useNetworkStatus();
 
     return (
         <>
             <Outlet context={{ session }} />
-            <Snackbar
-                isOpen={!isOnline}
-                isStatic
-                severity='info'
-                message='You appear to be offline. Please check your network connection to make the most of Streamability'
-            />
+            <OfflineSnackbar />
         </>
     );
 };

--- a/src/screens/dashboard/DashboardLayout.tsx
+++ b/src/screens/dashboard/DashboardLayout.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from 'react-router-dom';
-import { useNetworkStatus, useProfileContext, useSessionContext } from '../../hooks';
+import { useProfileContext, useSessionContext } from '../../hooks';
 import React from 'react';
-import { Snackbar } from '../../components';
+import { OfflineSnackbar } from '../../components';
 
 /**
  * Wrapper for all dashboard screens
@@ -10,17 +10,11 @@ import { Snackbar } from '../../components';
 const DashboardLayout: React.FC = () => {
     const { session, setSession } = useSessionContext();
     const { profile, setProfile } = useProfileContext();
-    const isOnline = useNetworkStatus();
 
     return (
         <>
             <Outlet context={{ session, setSession, profile, setProfile }} />
-            <Snackbar
-                isOpen={!isOnline}
-                isStatic
-                severity='info'
-                message='You appear to be offline. Please check your network connection to make the most of Streamability'
-            />
+            <OfflineSnackbar />
         </>
     );
 };

--- a/src/screens/dashboard/DashboardLayout.tsx
+++ b/src/screens/dashboard/DashboardLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom';
-import { useProfileContext, useSessionContext } from '../../hooks';
+import { useNetworkStatus, useProfileContext, useSessionContext } from '../../hooks';
 import React from 'react';
+import { Snackbar } from '../../components';
 
 /**
  * Wrapper for all dashboard screens
@@ -9,10 +10,17 @@ import React from 'react';
 const DashboardLayout: React.FC = () => {
     const { session, setSession } = useSessionContext();
     const { profile, setProfile } = useProfileContext();
+    const isOnline = useNetworkStatus();
 
     return (
         <>
             <Outlet context={{ session, setSession, profile, setProfile }} />
+            <Snackbar
+                isOpen={!isOnline}
+                isStatic
+                severity='info'
+                message='You appear to be offline. Please check your network connection to make the most of Streamability'
+            />
         </>
     );
 };

--- a/src/screens/search_results/SearchResultsScreen.tsx
+++ b/src/screens/search_results/SearchResultsScreen.tsx
@@ -1,8 +1,8 @@
 import { useLoaderData } from 'react-router-dom';
 import React, { useState, useEffect, useMemo } from 'react';
-import { EmptySearchResults, Snackbar } from '../../components';
+import { EmptySearchResults, OfflineSnackbar } from '../../components';
 import { ShowData } from '../../types';
-import { useNetworkStatus, useProfileContext, useWindowSize } from '../../hooks';
+import { useProfileContext, useWindowSize } from '../../hooks';
 import { getShowsByName } from '../../helpers';
 import Logger from '../../logger';
 import SearchResultCards from './SearchResultsCards';
@@ -37,7 +37,6 @@ const SearchResultsScreen: React.FC = () => {
     const query: string = useLoaderData() as string;
     const windowSize = useWindowSize();
     const { profile, setProfile } = useProfileContext();
-    const isOnline = useNetworkStatus();
     const storageItem = localStorage.getItem('streamabilityView');
     const initialView = storageItem === 'grid' ? 'grid' : 'list';
     const [viewState, setViewState] = useState<'list' | 'grid'>(initialView);
@@ -97,12 +96,7 @@ const SearchResultsScreen: React.FC = () => {
                 setShowDetails={setShowDetails}
             />
             {cards}
-            <Snackbar
-                isOpen={!isOnline}
-                isStatic
-                severity='info'
-                message='You appear to be offline. Please check your network connection to make the most of Streamability'
-            />
+            <OfflineSnackbar />
         </>
     );
 };

--- a/src/screens/search_results/SearchResultsScreen.tsx
+++ b/src/screens/search_results/SearchResultsScreen.tsx
@@ -1,8 +1,8 @@
 import { useLoaderData } from 'react-router-dom';
 import React, { useState, useEffect, useMemo } from 'react';
-import { EmptySearchResults } from '../../components';
+import { EmptySearchResults, Snackbar } from '../../components';
 import { ShowData } from '../../types';
-import { useProfileContext, useWindowSize } from '../../hooks';
+import { useNetworkStatus, useProfileContext, useWindowSize } from '../../hooks';
 import { getShowsByName } from '../../helpers';
 import Logger from '../../logger';
 import SearchResultCards from './SearchResultsCards';
@@ -37,6 +37,7 @@ const SearchResultsScreen: React.FC = () => {
     const query: string = useLoaderData() as string;
     const windowSize = useWindowSize();
     const { profile, setProfile } = useProfileContext();
+    const isOnline = useNetworkStatus();
     const storageItem = localStorage.getItem('streamabilityView');
     const initialView = storageItem === 'grid' ? 'grid' : 'list';
     const [viewState, setViewState] = useState<'list' | 'grid'>(initialView);
@@ -96,6 +97,12 @@ const SearchResultsScreen: React.FC = () => {
                 setShowDetails={setShowDetails}
             />
             {cards}
+            <Snackbar
+                isOpen={!isOnline}
+                isStatic
+                severity='info'
+                message='You appear to be offline. Please check your network connection to make the most of Streamability'
+            />
         </>
     );
 };


### PR DESCRIPTION
## Description

<!-- Provide a description of the changes made -->
This snackbar will automatically appear when network connection is lost. When it is regained, it will automatically disappear. The component is set to `isStatic` so it will not disappear after 3 seconds, but the user can still clear the notification.

The custom hook simply return a boolean that is update on network status change. This will likely be used again in #671 and any other offline related tickets.

- Create custom hook to detect network changes
- Create snackbar component to be used to notify users of offline state
- Add snackbar to every screen
- Create #671

If you notice I missed any screen, please let me know. 

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created

## Screenshot

![image](https://github.com/Thenlie/Streamability/assets/41388783/c24ea7a2-d0ee-422c-aaa1-317f6333959e)

Closes #589 
