### PR TITLE
Add pagination to search results screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+tmp
 
 storybook-static

--- a/src/__tests__/screens/assets/showData.ts
+++ b/src/__tests__/screens/assets/showData.ts
@@ -13,7 +13,7 @@ const MOVIE_DATA: ShowData[] = [
         vote_count: 23740,
         overview: 'After being held captive in an Afghan cave, billionaire engineer Tony Stark creates a unique weaponized suit of armor to fight evil.',
         media_type: 'movie',
-        networks: [
+        providers: [
             {
                 name: 'Disney Plus',
                 id: 1234,

--- a/src/helpers/getMovieUtils.ts
+++ b/src/helpers/getMovieUtils.ts
@@ -1,6 +1,7 @@
 import Logger from '../logger';
 import { MovieResults, MovieDetailsData, ShowProviders, ShowData, DiscoverMovie } from '../types';
 import { MOVIE_RATINGS } from './constants';
+import { convertResultsToShowType } from './showTypeUtils';
 
 const LOG = new Logger('getMovieUtils');
 /**
@@ -19,19 +20,7 @@ const getMoviesByName = async (name: string): Promise<ShowData[] | null> => {
     }
     const data = (await response.json()) as MovieResults;
     if (!data.results) return null;
-    return data.results.map((movie) => {
-        return {
-            id: movie.id,
-            poster_path: movie.poster_path,
-            title: movie.title,
-            release_date: movie.release_date,
-            vote_average: movie.vote_average,
-            vote_count: movie.vote_count,
-            overview: movie.overview,
-            media_type: 'movie',
-            genre_ids: movie.genre_ids,
-        };
-    });
+    return convertResultsToShowType(data);
 };
 
 /**
@@ -111,20 +100,7 @@ const getMovieTrending = async (): Promise<ShowData[] | null> => {
     }
     const data = (await response.json()) as MovieResults;
     if (!data.results) return null;
-    return data.results.map((movie) => {
-        return {
-            id: movie.id,
-            poster_path: movie.poster_path,
-            banner_path: movie.backdrop_path,
-            title: movie.title,
-            release_date: movie.release_date,
-            vote_average: movie.vote_average,
-            vote_count: movie.vote_count,
-            overview: movie.overview,
-            media_type: 'movie',
-            genre_ids: movie.genre_ids,
-        };
-    });
+    return convertResultsToShowType(data);
 };
 
 /**
@@ -143,19 +119,7 @@ const getMovieRecommendations = async (id: number): Promise<ShowData[] | null> =
     }
     const data = (await response.json()) as MovieResults;
     if (!data.results || data.results.length < 1) return null;
-    return data.results.map((rec) => {
-        return {
-            id: rec.id,
-            overview: rec.overview,
-            poster_path: rec.poster_path,
-            release_date: rec.release_date,
-            title: rec.title,
-            vote_average: rec.vote_average,
-            vote_count: rec.vote_count,
-            media_type: 'movie',
-            genre_ids: rec.genre_ids,
-        };
-    });
+    return convertResultsToShowType(data);
 };
 
 /**
@@ -198,20 +162,7 @@ const getDiscoverMovies = async ({
 
     const data = (await response.json()) as MovieResults;
     if (!data.results || data.results.length < 1) return null;
-    return data.results.map((movie) => {
-        return {
-            id: movie.id,
-            overview: movie.overview,
-            poster_path: movie.poster_path,
-            banner_path: movie.backdrop_path,
-            release_date: movie.release_date,
-            title: movie.title,
-            vote_average: movie.vote_average,
-            vote_count: movie.vote_count,
-            media_type: 'movie',
-            genre_ids: movie.genre_ids,
-        };
-    });
+    return convertResultsToShowType(data);
 };
 
 export {

--- a/src/helpers/getShowUtils.ts
+++ b/src/helpers/getShowUtils.ts
@@ -1,7 +1,7 @@
 /* eslint-disable prettier/prettier */
 import Logger from '../logger';
-import { MovieData, ShowData, ShowResults, TvData } from '../types';
-import { filterShowsByType } from './showFilterUtils';
+import { ShowData, ShowResults } from '../types';
+import { convertResultsToShowType } from './showTypeUtils';
 
 const LOG = new Logger('getShowUtils');
 
@@ -27,21 +27,7 @@ const getShowsByName = async (query: string): Promise<ShowData[] | null> => {
         return null;
     }
 
-    const showData = data.results.map((show) => {
-        return {
-            id: show.id,
-            poster_path: show.poster_path,
-            vote_average: show.vote_average,
-            vote_count: show.vote_count,
-            overview: show.overview,
-            media_type: show.media_type,
-            genre_ids: show.genre_ids,
-            title: show.media_type === 'movie' ? (show as MovieData).title : (show as TvData).name,
-            release_date: show.media_type === 'movie' ? (show as MovieData).release_date : (show as TvData).first_air_date,
-        };
-    });
-
-    return filterShowsByType(showData, 'both');
+    return convertResultsToShowType(data);
 };
 
 export { getShowsByName };

--- a/src/helpers/getShowUtils.ts
+++ b/src/helpers/getShowUtils.ts
@@ -7,14 +7,14 @@ const LOG = new Logger('getShowUtils');
 
 /**
  * Returns a list of shows based on a given search query.
- * @param name | Name of show being queried
+ * @param query | Name of show being queried
  * @returns {Promise<ShowData[]>} | List of movies by searched query.
  */
-const getShowsByName = async (name: string): Promise<ShowData[] | null> => {
+const getShowsByName = async (query: string): Promise<ShowData[] | null> => {
     const response = await fetch(
         `https://api.themoviedb.org/3/search/multi?api_key=${
             import.meta.env.VITE_MOVIEDB_KEY
-        }&language=en-US&query=${name}&page=1&include_adult=false`
+        }&language=en-US&query=${query}&page=1&include_adult=false`
     );
     if (!response.ok) {
         LOG.error('Fetch request failed with a status of ' + response.status);

--- a/src/helpers/getTvUtils.ts
+++ b/src/helpers/getTvUtils.ts
@@ -1,5 +1,6 @@
 import Logger from '../logger';
 import { ShowData, TvDetailsData, TvResults, ShowProviders, DiscoverTv } from '../types';
+import { convertResultsToShowType } from './showTypeUtils';
 
 const LOG = new Logger('getTvUtils');
 
@@ -19,19 +20,7 @@ const getTvByName = async (name: string): Promise<ShowData[] | null> => {
     }
     const data = (await response.json()) as TvResults;
     if (!data.results) return null;
-    return data.results.map((tv) => {
-        return {
-            id: tv.id,
-            poster_path: tv.poster_path,
-            title: tv.name,
-            release_date: tv.first_air_date,
-            vote_average: tv.vote_average,
-            vote_count: tv.vote_count,
-            overview: tv.overview,
-            media_type: 'tv',
-            genre_ids: tv.genre_ids,
-        };
-    });
+    return convertResultsToShowType(data);
 };
 
 /**
@@ -103,20 +92,7 @@ const getTvTrending = async (): Promise<ShowData[] | null> => {
     }
     const data = (await response.json()) as TvResults;
     if (!data.results) return null;
-    return data.results.map((tv) => {
-        return {
-            id: tv.id,
-            poster_path: tv.poster_path,
-            banner_path: tv.backdrop_path,
-            title: tv.original_name,
-            release_date: tv.first_air_date,
-            vote_average: tv.vote_average,
-            vote_count: tv.vote_count,
-            overview: tv.overview,
-            media_type: 'tv',
-            genre_ids: tv.genre_ids,
-        };
-    });
+    return convertResultsToShowType(data);
 };
 
 /**
@@ -135,21 +111,7 @@ const getTvRecommendations = async (id: number): Promise<ShowData[] | null> => {
     }
     const data = (await response.json()) as TvResults;
     if (!data.results || data.results.length < 1) return null;
-    const recommendations: ShowData[] = [];
-    data.results.map((rec) =>
-        recommendations.push({
-            id: rec.id,
-            overview: rec.overview,
-            poster_path: rec.poster_path,
-            release_date: rec.first_air_date,
-            title: rec.name,
-            vote_average: rec.vote_average,
-            vote_count: rec.vote_count,
-            media_type: 'tv',
-            genre_ids: rec.genre_ids,
-        })
-    );
-    return recommendations;
+    return convertResultsToShowType(data);
 };
 
 /**
@@ -191,20 +153,7 @@ const getDiscoverTv = async ({
 
     const data = (await response.json()) as TvResults;
     if (!data.results || data.results.length < 1) return null;
-    return data.results.map((tv) => {
-        return {
-            id: tv.id,
-            overview: tv.overview,
-            poster_path: tv.poster_path,
-            banner_path: tv.backdrop_path,
-            release_date: tv.first_air_date,
-            title: tv.name,
-            vote_average: tv.vote_average,
-            vote_count: tv.vote_count,
-            media_type: 'tv',
-            genre_ids: tv.genre_ids,
-        };
-    });
+    return convertResultsToShowType(data);
 };
 
 export {

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -7,3 +7,4 @@ export * from './showFilterUtils';
 export * from './showSortUtils';
 export * from './stringFormatUtils';
 export * from './validationUtils';
+export * from './showTypeUtils';

--- a/src/helpers/showTypeUtils.ts
+++ b/src/helpers/showTypeUtils.ts
@@ -1,0 +1,36 @@
+import { MovieData, MovieResults, ShowData, ShowResults, TvData, TvResults } from '../types';
+import { filterShowsByType } from './showFilterUtils';
+
+/**
+ * Convert movie or tv results to the ShowData type.
+ * @param data | Results data being converted
+ * @returns {ShowData[] | null}
+ */
+const convertResultsToShowType = (
+    data: MovieResults | TvResults | ShowResults
+): ShowData[] | null => {
+    if (!data || !data.results) return null;
+
+    const showData = data.results.map((movie) => {
+        return {
+            id: movie.id,
+            poster_path: movie.poster_path,
+            banner_path: movie.backdrop_path,
+            vote_average: movie.vote_average,
+            vote_count: movie.vote_count,
+            overview: movie.overview,
+            media_type: movie.media_type,
+            genre_ids: movie.genre_ids,
+            title:
+                movie.media_type === 'movie' ? (movie as MovieData).title : (movie as TvData).name,
+            release_date:
+                movie.media_type === 'movie'
+                    ? (movie as MovieData).release_date
+                    : (movie as TvData).first_air_date,
+        };
+    });
+
+    return filterShowsByType(showData, 'both');
+};
+
+export { convertResultsToShowType };

--- a/src/hooks/__tests__/constants.ts
+++ b/src/hooks/__tests__/constants.ts
@@ -112,7 +112,7 @@ export const SHOW_DATA: ShowData = {
     overview:
         'After being held captive in an Afghan cave, billionaire engineer Tony Stark creates a unique weaponized suit of armor to fight evil.',
     media_type: 'movie',
-    networks: [
+    providers: [
         {
             name: 'Disney Plus',
             id: 1234,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -6,6 +6,7 @@ import useDebounceValue from './useDebounceValue';
 import useTrendingShows from './useTrendingShows';
 import useGetProfileArray from './useGetProfileArray';
 import useNetworkStatus from './useNetworkStatus';
+import usePaginatedData from './usePaginatedData';
 
 export {
     useProfileContext,
@@ -17,4 +18,5 @@ export {
     useTrendingShows,
     useGetProfileArray,
     useNetworkStatus,
+    usePaginatedData,
 };

--- a/src/hooks/usePaginatedData.ts
+++ b/src/hooks/usePaginatedData.ts
@@ -12,7 +12,9 @@ interface PaginatedDataProps {
 }
 
 /**
- * Custom hook to handle TMDB data pagination
+ * Custom hook to handle TMDB data pagination.
+ * Initially returns the first page of search results
+ * along with a function to fetch the next page.
  */
 const usePaginatedData = ({ query }: PaginatedDataProps) => {
     const [data, setData] = useState<ShowData[] | null>(null);

--- a/src/hooks/usePaginatedData.ts
+++ b/src/hooks/usePaginatedData.ts
@@ -17,7 +17,7 @@ interface PaginatedDataProps {
 const usePaginatedData = ({ query }: PaginatedDataProps) => {
     const [data, setData] = useState<ShowData[] | null>(null);
     const [moreToFetch, setMoreToFetch] = useState<boolean>(true);
-    const [loading, setLoading] = useState<boolean>(false);
+    const [loading, setLoading] = useState<boolean>(true);
     const [page, setPage] = useState<number>(1);
 
     const refetch = () => {
@@ -25,7 +25,7 @@ const usePaginatedData = ({ query }: PaginatedDataProps) => {
             if (!moreToFetch) return;
 
             setLoading(true);
-            LOG.debug(page);
+            LOG.debug(page + ' ' + query);
             const response = await fetch(
                 `https://api.themoviedb.org/3/search/multi?api_key=${
                     import.meta.env.VITE_MOVIEDB_KEY
@@ -74,11 +74,15 @@ const usePaginatedData = ({ query }: PaginatedDataProps) => {
     };
 
     useEffect(() => {
+        if (page === 1) refetch();
+    }, [page]);
+
+    useEffect(() => {
         setPage(1);
         setData(null);
         setMoreToFetch(true);
-        setLoading(false);
-        refetch();
+        setLoading(true);
+        if (page === 1) refetch();
     }, [query]);
 
     return { data, loading, moreToFetch, refetch };

--- a/src/hooks/usePaginatedData.ts
+++ b/src/hooks/usePaginatedData.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import { MovieData, ShowData, ShowResults, TvData } from '../types';
+import Logger from '../logger';
+
+const LOG = new Logger('usePaginatedData');
+
+interface PaginatedDataProps {
+    /**
+     * Search query for TMDB
+     */
+    query: string;
+}
+
+/**
+ * Custom hook to handle TMDB data pagination
+ */
+const usePaginatedData = ({ query }: PaginatedDataProps) => {
+    const [data, setData] = useState<ShowData[] | null>(null);
+    const [moreToFetch, setMoreToFetch] = useState<boolean>(true);
+    const [loading, setLoading] = useState<boolean>(false);
+    const [page, setPage] = useState<number>(1);
+
+    const refetch = () => {
+        const fetchHandler = async () => {
+            if (!moreToFetch) return;
+
+            setLoading(true);
+            LOG.debug(page);
+            const response = await fetch(
+                `https://api.themoviedb.org/3/search/multi?api_key=${
+                    import.meta.env.VITE_MOVIEDB_KEY
+                }&language=en-US&query=${query}&page=${page}&include_adult=false`
+            );
+            if (!response.ok) {
+                LOG.error(
+                    'Error fetching next page of data!' + response.status + response.statusText
+                );
+                setLoading(false);
+                return;
+            }
+
+            const json = (await response.json()) as ShowResults;
+            if (!json.results) {
+                setLoading(false);
+                return;
+            }
+
+            const newData: ShowData[] = json.results.map((show) => {
+                return {
+                    id: show.id,
+                    poster_path: show.poster_path,
+                    vote_average: show.vote_average,
+                    vote_count: show.vote_count,
+                    overview: show.overview,
+                    media_type: show.media_type,
+                    genre_ids: show.genre_ids,
+                    title:
+                        show.media_type === 'movie'
+                            ? (show as MovieData).title
+                            : (show as TvData).name,
+                    release_date:
+                        show.media_type === 'movie'
+                            ? (show as MovieData).release_date
+                            : (show as TvData).first_air_date,
+                };
+            });
+
+            setMoreToFetch(json.total_pages > page);
+            setPage((prev) => prev + 1);
+            data ? setData([...data, ...newData]) : setData(newData);
+            setLoading(false);
+        };
+        fetchHandler();
+    };
+
+    useEffect(() => {
+        setPage(1);
+        setData(null);
+        setMoreToFetch(true);
+        setLoading(false);
+        refetch();
+    }, [query]);
+
+    return { data, loading, moreToFetch, refetch };
+};
+
+export default usePaginatedData;

--- a/src/screens/search_results/SearchResultsCards.tsx
+++ b/src/screens/search_results/SearchResultsCards.tsx
@@ -36,7 +36,7 @@ const SearchResultsCards: React.FC<SearchResultsCardsProps> = ({
                 viewState === 'grid'
                     ? 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
                     : 'flex flex-wrap justify-center'
-            } pb-6
+            }
             `}
         >
             {details?.map((item, i) => {

--- a/src/screens/search_results/SearchResultsHeader.tsx
+++ b/src/screens/search_results/SearchResultsHeader.tsx
@@ -24,11 +24,15 @@ interface SearchResultsHeaderProps {
     /**
      * Data of shows returned from the requested search
      */
-    showDetails?: { data: ShowData[] | null; hash: number };
+    showDetails?: ShowData[] | null;
     /**
      * Function to set the react state of the show data
      */
-    setShowDetails?: Dispatch<SetStateAction<{ data: ShowData[] | null; hash: number }>>;
+    setShowDetails?: Dispatch<SetStateAction<ShowData[] | null>>;
+    /**
+     * Function to trigger a re-render in the search results screen
+     */
+    setHash?: Dispatch<SetStateAction<number>>;
     /**
      * All controls are disabled when `true`, defaults to `false`
      */
@@ -45,6 +49,7 @@ const SearchResultsHeader: React.FC<SearchResultsHeaderProps> = ({
     setViewState,
     showDetails,
     setShowDetails,
+    setHash,
     disableControls = false,
 }) => {
     const [sortState, setSortState] = useState<'alpha' | 'rev' | 'none'>('none');
@@ -53,18 +58,21 @@ const SearchResultsHeader: React.FC<SearchResultsHeaderProps> = ({
     const handleViewToggle = (view: 'grid' | 'list') => {
         setViewState?.(view);
         localStorage.setItem('streamabilityView', view);
+        setHash?.(Math.random());
     };
 
     const handleSortAlpha = () => {
-        const sortedShows = sortShowsAlphaAsc(showDetails?.data || []);
-        setShowDetails?.({ data: sortedShows, hash: Math.random() });
+        const sortedShows = sortShowsAlphaAsc(showDetails || []);
+        setShowDetails?.(sortedShows);
         setSortState('alpha');
+        setHash?.(Math.random());
     };
 
     const handleSortRevAlpha = () => {
-        const sortedShows = sortShowsAlphaDesc(showDetails?.data || []);
-        setShowDetails?.({ data: sortedShows, hash: Math.random() });
+        const sortedShows = sortShowsAlphaDesc(showDetails || []);
+        setShowDetails?.(sortedShows);
         setSortState('rev');
+        setHash?.(Math.random());
     };
 
     const handleRemoveSort = () => {
@@ -73,8 +81,9 @@ const SearchResultsHeader: React.FC<SearchResultsHeaderProps> = ({
             LOG.error('Unable to un-sort shows!');
             return;
         }
-        setShowDetails?.({ data: JSON.parse(unsortedShows), hash: Math.random() });
+        setShowDetails?.(JSON.parse(unsortedShows));
         setSortState('none');
+        setHash?.(Math.random());
     };
 
     return (

--- a/src/screens/search_results/SearchResultsScreen.tsx
+++ b/src/screens/search_results/SearchResultsScreen.tsx
@@ -86,13 +86,14 @@ const SearchResultsScreen: React.FC = () => {
                 setShowDetails={setData}
                 setHash={setHash}
             />
+            {cards}
             <Button
                 title='Refetch'
                 loading={dataLoading}
                 onClick={refetch}
                 disabled={!moreToFetch}
+                sx={{ display: moreToFetch ? 'block' : 'none', marginBottom: 2 }}
             />
-            {cards}
             <OfflineSnackbar />
         </>
     );

--- a/src/screens/search_results/SearchResultsScreen.tsx
+++ b/src/screens/search_results/SearchResultsScreen.tsx
@@ -1,7 +1,6 @@
 import { useLoaderData } from 'react-router-dom';
 import React, { useState, useEffect, useMemo } from 'react';
 import { Button, EmptySearchResults, OfflineSnackbar } from '../../components';
-import { ShowData } from '../../types';
 import { usePaginatedData, useProfileContext, useWindowSize } from '../../hooks';
 import Logger from '../../logger';
 import SearchResultCards from './SearchResultsCards';
@@ -39,13 +38,14 @@ const SearchResultsScreen: React.FC = () => {
     const storageItem = localStorage.getItem('streamabilityView');
     const initialView = storageItem === 'grid' ? 'grid' : 'list';
     const [viewState, setViewState] = useState<'list' | 'grid'>(initialView);
-    const [showDetails, setShowDetails] = useState<{ data: ShowData[] | null; hash: number }>({
-        data: null,
-        hash: 0,
-    });
-    const { data, loading: dataLoading, moreToFetch, refetch } = usePaginatedData({ query: query });
-
-    LOG.debug(data + String(dataLoading) + String(moreToFetch));
+    const [hash, setHash] = useState<number>(1);
+    const {
+        data,
+        setData,
+        loading: dataLoading,
+        moreToFetch,
+        refetch,
+    } = usePaginatedData({ query: query });
 
     if (!storageItem) localStorage.setItem('streamabilityView', initialView);
 
@@ -66,7 +66,7 @@ const SearchResultsScreen: React.FC = () => {
                 setProfile={setProfile}
             />
         );
-    }, [data, viewState]);
+    }, [data, hash, viewState]);
 
     if (!data) {
         return <SearchResultsLoader query={query} windowSize={windowSize} viewState={viewState} />;
@@ -82,8 +82,9 @@ const SearchResultsScreen: React.FC = () => {
                 query={query}
                 viewState={viewState}
                 setViewState={setViewState}
-                showDetails={showDetails}
-                setShowDetails={setShowDetails}
+                showDetails={data}
+                setShowDetails={setData}
+                setHash={setHash}
             />
             <Button
                 title='Refetch'

--- a/src/screens/search_results/SearchResultsScreen.tsx
+++ b/src/screens/search_results/SearchResultsScreen.tsx
@@ -3,7 +3,6 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { Button, EmptySearchResults, OfflineSnackbar } from '../../components';
 import { ShowData } from '../../types';
 import { usePaginatedData, useProfileContext, useWindowSize } from '../../hooks';
-import { getShowsByName } from '../../helpers';
 import Logger from '../../logger';
 import SearchResultCards from './SearchResultsCards';
 import { SearchResultsLoader } from '../loaders';
@@ -44,7 +43,6 @@ const SearchResultsScreen: React.FC = () => {
         data: null,
         hash: 0,
     });
-    const [pageLoading, setPageLoading] = useState<boolean>(false);
     const { data, loading: dataLoading, moreToFetch, refetch } = usePaginatedData({ query: query });
 
     LOG.debug(data + String(dataLoading) + String(moreToFetch));
@@ -70,7 +68,7 @@ const SearchResultsScreen: React.FC = () => {
         );
     }, [data, viewState]);
 
-    if (pageLoading) {
+    if (!data) {
         return <SearchResultsLoader query={query} windowSize={windowSize} viewState={viewState} />;
     }
 

--- a/src/screens/search_results/SearchResultsScreen.tsx
+++ b/src/screens/search_results/SearchResultsScreen.tsx
@@ -88,7 +88,7 @@ const SearchResultsScreen: React.FC = () => {
             />
             {cards}
             <Button
-                title='Refetch'
+                title='Load More'
                 loading={dataLoading}
                 onClick={refetch}
                 disabled={!moreToFetch}

--- a/src/stories/constants.ts
+++ b/src/stories/constants.ts
@@ -69,7 +69,7 @@ export const MOVIE_DATA: ShowData = {
     overview:
         'After being held captive in an Afghan cave, billionaire engineer Tony Stark creates a unique weaponized suit of armor to fight evil.',
     media_type: 'movie',
-    networks: [
+    providers: [
         {
             name: 'Disney Plus',
             id: 1234,

--- a/src/types/tmdb/movie.ts
+++ b/src/types/tmdb/movie.ts
@@ -1,4 +1,4 @@
-import { ShowGenre } from './show';
+import { ShowGenre, ShowProviders } from './show';
 
 /**
  * Returned by TMDB as non-detailed info
@@ -63,6 +63,7 @@ export interface MovieDetailsData extends MovieData {
         posters: MovieImage[];
     };
     imdb_id: string;
+    media_type: 'movie';
     production_companies: [
         {
             id: number;
@@ -104,6 +105,7 @@ export interface MovieDetailsData extends MovieData {
     ];
     status: string;
     tagline: string;
+    'watch/providers': ShowProviders;
 }
 
 export interface DiscoverMovie {

--- a/src/types/tmdb/show.ts
+++ b/src/types/tmdb/show.ts
@@ -15,10 +15,10 @@ export interface ShowGenre {
  * More detailed information about streaming providers
  */
 export interface ShowProviderInfo {
-    display_priority?: number;
-    logo_path?: string;
-    provider_id?: number;
-    provider_name?: string;
+    display_priority: number;
+    logo_path: string;
+    provider_id: number;
+    provider_name: string;
 }
 
 /**
@@ -103,14 +103,12 @@ export interface ShowData {
     title: string;
     vote_average?: number;
     vote_count?: number;
-    networks?: [
-        {
-            name: string;
-            id: number;
-            logo_path: string | null;
-            origin_country: string;
-        },
-    ];
+    providers?: {
+        name: string;
+        id: number;
+        logo_path: string | null;
+        origin_country: string;
+    }[];
     media_type: 'movie' | 'tv' | 'person';
     genre_ids?: number[];
 }

--- a/src/types/tmdb/show.ts
+++ b/src/types/tmdb/show.ts
@@ -120,8 +120,8 @@ export interface ShowData {
  * https://developer.themoviedb.org/reference/search-multi
  */
 export interface ShowResults {
-    page?: number;
+    page: number;
     results?: Array<MovieData | TvData>;
-    total_pages?: number;
-    total_results?: number;
+    total_pages: number;
+    total_results: number;
 }

--- a/src/types/tmdb/tv.ts
+++ b/src/types/tmdb/tv.ts
@@ -1,4 +1,4 @@
-import { ShowGenre } from './show';
+import { ShowGenre, ShowProviders } from './show';
 
 /**
  * Returned by TMDB as non-detailed info
@@ -64,6 +64,7 @@ export interface TvDetailsData extends TvData {
         vote_average: number;
         vote_count: number;
     };
+    media_type: 'tv';
     next_episode_to_air: null;
     networks: [
         {
@@ -128,6 +129,7 @@ export interface TvDetailsData extends TvData {
             },
         ];
     };
+    'watch/providers': ShowProviders;
 }
 
 export interface DiscoverTv {


### PR DESCRIPTION
## Description

This PR adds pagination to the search results screen. You can now fetch a new page of search results if it is available. This will be appended to the bottom of the current screen. 

This respects the user sort. If the first page is sorted, it will not be updated on refetch. If the unsort button is clicked, the TMDB sort order is returned.

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created

## Demo

> NOTE: Had to share a zip since 10 seconds is too long for GitHub 😂 

[Untitled.mov.zip](https://github.com/Thenlie/Streamability/files/13185459/Untitled.mov.zip)

## Screenshot

![image](https://github.com/Thenlie/Streamability/assets/41388783/5c57f7fe-88e2-45b5-a236-f00347a7775d)

Closes #482 