### PR TITLE
Fix runtime '0' bug

### DIFF
--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -187,11 +187,11 @@ const ShowDetailsScreen: React.FC = () => {
                             </Typ>
                         )}
                         <Typ align='left'>{details.age_rating}</Typ>
-                        {details.runtime && (
-                            <Typ align='left' variant='body2'>
-                                {details.runtime} minutes
-                            </Typ>
-                        )}
+                        <Typ align='left' variant='body2'>
+                            {details.runtime && details.runtime > 0
+                                ? details.runtime + ' minutes'
+                                : 'No runtime available'}
+                        </Typ>
                     </div>
                     <Rating
                         vote_average={details.vote_average || 0}


### PR DESCRIPTION
## Description

<!-- Provide a description of the changes made -->
I don't fully understand how this bug was happening, but this fixes it. If we get a runtime of 0, we display "no runtime available" instead.

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created

## Screenshot

<img width="514" alt="image" src="https://github.com/Thenlie/Streamability/assets/41388783/f4613010-dba2-433e-aa2a-933ab228e5ca">

Closes #659 