### PR TITLE
Fix show poster aspect ration to 2:3

### DIFF
--- a/src/components/ShowPoster.tsx
+++ b/src/components/ShowPoster.tsx
@@ -232,8 +232,7 @@ const ShowPoster: React.FC<ShowPosterProps> = ({
                     sx={{
                         width: 180,
                         minWidth: 180,
-                        height: 270,
-                        minHeight: 270,
+                        aspectRatio: 2 / 3,
                         boxShadow: 5,
                         '&:hover': { opacity: 0.8 },
                     }}

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -161,9 +161,10 @@ const ShowDetailsScreen: React.FC = () => {
     return (
         <>
             <section className='m-6 mb-8 flex flex-col lg:flex-row'>
-                <div className='rounded-md m-3 w-[250px] lg:w-[330px] h-[400px] lg:h-[550px]'>
+                <div className='rounded-md m-3 w-[250px] lg:w-[330px]'>
                     <img
-                        className='w-[250px] lg:w-[330px] h-[400px] lg:h-[550px] max-w-none rounded-md'
+                        className='w-[250px] lg:w-[330px] max-w-none rounded-md'
+                        style={{ aspectRatio: 2 / 3 }}
                         src={
                             details.poster_path
                                 ? `https://image.tmdb.org/t/p/w500${details.poster_path}`


### PR DESCRIPTION
## Description

<!-- Provide a description of the changes made -->
Subtle change, but fixed the show poster aspect ratio. This fixes the show poster component as well as the poster on the show details screen.

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created

## Screenshots

### Before

<img width="351" alt="image" src="https://github.com/Thenlie/Streamability/assets/41388783/e2568c86-3b03-4386-b5f6-b602665993d7">

### After

<img width="350" alt="image" src="https://github.com/Thenlie/Streamability/assets/41388783/67b5dad5-07cd-4187-86ff-fcc45a2e034e">

Closes #662 