### PR TITLE
Add unit tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,10 +5,10 @@
 | [src/components/Navigation.tsx](src/components/Navigation.tsx#L88) | 88 | Error handling if any |
 | [src/components/Navigation.tsx](src/components/Navigation.tsx#L93) | 93 | #162 Use MUI ThemeProvider |
 | [src/components/Navigation.tsx](src/components/Navigation.tsx#L242) | 242 | Add a transition when search is expanded or collapsed |
-| [src/screens/DiscoverScreen.tsx](src/screens/DiscoverScreen.tsx#L62) | 62 | #613 Dynamic date range |
+| [src/screens/DiscoverScreen.tsx](src/screens/DiscoverScreen.tsx#L61) | 61 | #613 Dynamic date range |
 | [src/screens/PageNotFoundScreen.tsx](src/screens/PageNotFoundScreen.tsx#L25) | 25 | Implement better error handling |
 | [src/screens/PageNotFoundScreen.tsx](src/screens/PageNotFoundScreen.tsx#L26) | 26 | Handle thrown responses with 'isRouteErrorResponse' |
-| [src/screens/ShowDetailsScreen.tsx](src/screens/ShowDetailsScreen.tsx#L156) | 156 | #438 Handle case when no details are ever returned |
+| [src/screens/ShowDetailsScreen.tsx](src/screens/ShowDetailsScreen.tsx#L175) | 175 | #691 Handle case when no details are ever returned |
 | [src/supabase/profiles.ts](src/supabase/profiles.ts#L253) | 253 | #587 Ensure country code is valid |
 | [src/__tests__/components/component.test.tsx](src/__tests__/components/component.test.tsx#L8) | 8 | #427 Re-enable tests when UI stable |
 | [src/__tests__/screens/authScreen.test.tsx](src/__tests__/screens/authScreen.test.tsx#L9) | 9 | #427 Re-enable tests when UI stable |

--- a/src/helpers/__tests__/constants.ts
+++ b/src/helpers/__tests__/constants.ts
@@ -1,5 +1,16 @@
 /* eslint-disable quotes */
-import { ShowData } from '../../types';
+import { Season, ShowData } from '../../types';
+
+const fakeSeason: Season = {
+    id: 1,
+    name: 'season 1',
+    season_number: 1,
+    episode_count: 5,
+    air_date: 'fake date',
+    vote_average: 1,
+    poster_path: 'fake poster',
+    overview: 'fake season',
+};
 
 /**
  * A sample show data array that can be used for unit testing
@@ -11,6 +22,7 @@ export const SHOW_DATA_ARRAY: ShowData[] = [
         poster_path: '/78lPtwv72eTNqFW9COBYI0dWDJa.jpg',
         title: 'Iron Man',
         release_date: '2008-04-30',
+        runtime: 126,
         vote_average: 7.639,
         vote_count: 24715,
         overview:
@@ -23,6 +35,7 @@ export const SHOW_DATA_ARRAY: ShowData[] = [
         poster_path: '/eHDez1uN5X2ZAq4niX7HvhyZIIO.jpg',
         title: 'Iron Man: Rise of Technovore',
         release_date: '2013-04-24',
+        runtime: 88,
         vote_average: 5.918,
         vote_count: 152,
         overview:
@@ -250,6 +263,7 @@ export const SHOW_DATA_ARRAY: ShowData[] = [
         poster_path: '/nTQWWH6CFtl37x1nPx8HRwbwvGn.jpg',
         title: 'Iron Man',
         release_date: '1994-09-24',
+        seasons: [fakeSeason, fakeSeason],
         vote_average: 6.702,
         vote_count: 85,
         overview:
@@ -262,6 +276,7 @@ export const SHOW_DATA_ARRAY: ShowData[] = [
         poster_path: '/zOTJT7JbzSrMBX2OCGPqUnkQA4y.jpg',
         title: 'Iron Man',
         release_date: '2010-10-01',
+        seasons: [fakeSeason, fakeSeason, fakeSeason, fakeSeason],
         vote_average: 7.211,
         vote_count: 76,
         overview:

--- a/src/helpers/__tests__/dateFormat.test.ts
+++ b/src/helpers/__tests__/dateFormat.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
-import { formatReleaseDate, DateSize, daysAgo } from '../dateFormatUtils';
+import { formatReleaseDate, DateSize, daysAgo, getReleaseDate } from '../dateFormatUtils';
+import { SHOW_DATA_ARRAY } from './constants';
 
 describe('formatReleaseDate', () => {
+    const date1 = '2022-04-20';
+    const date2 = '2000-01-01';
+    const date3 = '1999-12-23';
+    const date4 = '2023-09-31';
+    const date5 = '2012-06-22';
     it('properly formats release date - LONG', () => {
-        const date1 = '2022-04-20';
-        const date2 = '2000-01-01';
-        const date3 = '1999-12-23';
-        const date4 = '2023-09-31';
-        const date5 = '2012-06-22';
         expect(formatReleaseDate(date1, DateSize.LONG)).toBe('April 20th, 2022');
         expect(formatReleaseDate(date2, DateSize.LONG)).toBe('January 1st, 2000');
         expect(formatReleaseDate(date3, DateSize.LONG)).toBe('December 23rd, 1999');
@@ -15,11 +16,6 @@ describe('formatReleaseDate', () => {
         expect(formatReleaseDate(date5, DateSize.LONG)).toBe('June 22nd, 2012');
     });
     it('properly formats release date - MEDIUM', () => {
-        const date1 = '2022-04-20';
-        const date2 = '2000-01-01';
-        const date3 = '1999-12-23';
-        const date4 = '2023-09-31';
-        const date5 = '2012-06-22';
         expect(formatReleaseDate(date1, DateSize.MEDIUM)).toBe('Apr 20th, 2022');
         expect(formatReleaseDate(date2, DateSize.MEDIUM)).toBe('Jan 1st, 2000');
         expect(formatReleaseDate(date3, DateSize.MEDIUM)).toBe('Dec 23rd, 1999');
@@ -27,11 +23,6 @@ describe('formatReleaseDate', () => {
         expect(formatReleaseDate(date5, DateSize.MEDIUM)).toBe('Jun 22nd, 2012');
     });
     it('properly formats release date - SHORT', () => {
-        const date1 = '2022-04-20';
-        const date2 = '2000-01-01';
-        const date3 = '1999-12-23';
-        const date4 = '2023-09-31';
-        const date5 = '2012-06-22';
         expect(formatReleaseDate(date1, DateSize.SHORT)).toBe('4-20-2022');
         expect(formatReleaseDate(date2, DateSize.SHORT)).toBe('1-1-2000');
         expect(formatReleaseDate(date3, DateSize.SHORT)).toBe('12-23-1999');
@@ -58,5 +49,20 @@ describe('daysAgo', () => {
         expect(daysAgo(1)).toBe('1999-12-31');
         expect(daysAgo(2)).toBe('1999-12-30');
         expect(daysAgo(3)).toBe('1999-12-29');
+    });
+});
+
+describe('getReleaseDate', () => {
+    it('return the properly formatted release date for a movie', () => {
+        expect(getReleaseDate(SHOW_DATA_ARRAY[0])).toBe('April 30th, 2008');
+        expect(getReleaseDate(SHOW_DATA_ARRAY[1])).toBe('April 24th, 2013');
+        expect(getReleaseDate(SHOW_DATA_ARRAY[2])).toBe('April 28th, 2010');
+        expect(getReleaseDate(SHOW_DATA_ARRAY[3])).toBe('April 18th, 2013');
+    });
+    it('return the properly formatted release date for a tv show', () => {
+        expect(getReleaseDate(SHOW_DATA_ARRAY[20])).toBe('September 24th, 1994');
+        expect(getReleaseDate(SHOW_DATA_ARRAY[21])).toBe('October 1st, 2010');
+        expect(getReleaseDate(SHOW_DATA_ARRAY[22])).toBe('April 24th, 2009');
+        expect(getReleaseDate(SHOW_DATA_ARRAY[23])).toBe('November 30th, 2010');
     });
 });

--- a/src/helpers/__tests__/dateFormat.test.ts
+++ b/src/helpers/__tests__/dateFormat.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { formatReleaseDate, DateSize } from '../dateFormatUtils';
+import { describe, expect, it, vi } from 'vitest';
+import { formatReleaseDate, DateSize, daysAgo } from '../dateFormatUtils';
 
 describe('formatReleaseDate', () => {
     it('properly formats release date - LONG', () => {
@@ -37,5 +37,26 @@ describe('formatReleaseDate', () => {
         expect(formatReleaseDate(date3, DateSize.SHORT)).toBe('12-23-1999');
         expect(formatReleaseDate(date4, DateSize.SHORT)).toBe('9-31-2023');
         expect(formatReleaseDate(date5, DateSize.SHORT)).toBe('6-22-2012');
+    });
+});
+
+describe('daysAgo', () => {
+    beforeAll(() => {
+        // January 1st, 2000
+        const mockDate = new Date(2000, 0, 1);
+        vi.useFakeTimers();
+        vi.setSystemTime(mockDate);
+    });
+    it('returns 180 days ago by default', () => {
+        expect(daysAgo()).toBe('1999-07-05');
+    });
+    it('returns the correct date when given a param', () => {
+        expect(daysAgo(181)).toBe('1999-07-04');
+        expect(daysAgo(182)).toBe('1999-07-03');
+        expect(daysAgo(183)).toBe('1999-07-02');
+        expect(daysAgo(90)).toBe('1999-10-03');
+        expect(daysAgo(1)).toBe('1999-12-31');
+        expect(daysAgo(2)).toBe('1999-12-30');
+        expect(daysAgo(3)).toBe('1999-12-29');
     });
 });

--- a/src/helpers/__tests__/stringFormat.test.ts
+++ b/src/helpers/__tests__/stringFormat.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { pluralizeString } from '../stringFormatUtils';
+import { getRuntime, pluralizeString } from '../stringFormatUtils';
+import { SHOW_DATA_ARRAY } from './constants';
 
 describe('pluralizeString', () => {
     // eslint-disable-next-line prettier/prettier
@@ -9,5 +10,20 @@ describe('pluralizeString', () => {
         expect(pluralizeString(2, 'rating')).toBe('ratings');
         expect(pluralizeString(3, 'rating')).toBe('ratings');
         expect(pluralizeString(100, 'rating')).toBe('ratings');
+    });
+});
+
+describe('getRuntime', () => {
+    it('return the properly formatted release date for a movie', () => {
+        expect(getRuntime(SHOW_DATA_ARRAY[0])).toBe('126 minutes');
+        expect(getRuntime(SHOW_DATA_ARRAY[1])).toBe('88 minutes');
+        expect(getRuntime(SHOW_DATA_ARRAY[2])).toBe('No runtime available');
+        expect(getRuntime(SHOW_DATA_ARRAY[3])).toBe('No runtime available');
+    });
+    it('return the properly formatted release date for a tv show', () => {
+        expect(getRuntime(SHOW_DATA_ARRAY[20])).toBe('2 seasons');
+        expect(getRuntime(SHOW_DATA_ARRAY[21])).toBe('4 seasons');
+        expect(getRuntime(SHOW_DATA_ARRAY[22])).toBe('No seasons available');
+        expect(getRuntime(SHOW_DATA_ARRAY[23])).toBe('No seasons available');
     });
 });

--- a/src/helpers/dateFormatUtils.ts
+++ b/src/helpers/dateFormatUtils.ts
@@ -1,3 +1,5 @@
+import { ShowData } from '../types';
+
 enum DateSize {
     LONG,
     MEDIUM,
@@ -20,9 +22,7 @@ enum Months {
 }
 
 /**
- * Returns a suffix such as 'st', 'nd', 'rd', or 'th'
- * for a given day of the month.
- *
+ * Returns a suffix such as 'st', 'nd', 'rd', or 'th' for a given day of the month.
  * @param day | day of the month
  * @returns {string} | suffix of the given day
  */
@@ -40,7 +40,6 @@ const getDaySuffix = (day: number): string => {
 
 /**
  * Format date returned from movieDB API request
- *
  * @param date | movieDB date 'yyyy-mm-dd'
  * @param size | the size of the formatted string to be returned
  * @returns {string} | formatted date
@@ -82,4 +81,29 @@ const daysAgo = (days?: number): string => {
     return startDate.toISOString().split('T')[0];
 };
 
-export { formatReleaseDate, daysAgo, DateSize };
+/**
+ * Formats release date if movie
+ * Formats runtime range if TV. If TV Show is ongoing, displays "YYYY - Present"
+ * @param details | Details of show including release date
+ */
+const getReleaseDate = (details: ShowData): string | null => {
+    if (!details.release_date || details.release_date.length !== 10) return null;
+
+    if (details.media_type === 'movie') {
+        return formatReleaseDate(details.release_date, DateSize.LONG);
+    }
+
+    if (details.media_type === 'tv' && details.next_air_date !== undefined) {
+        return `${formatReleaseDate(details.release_date, DateSize.SHORT).slice(-4)} - Present`;
+    } else if (details.end_date) {
+        return `${formatReleaseDate(details.release_date, DateSize.SHORT).slice(
+            -4
+        )} - ${formatReleaseDate(details.end_date, DateSize.SHORT).slice(-4)}`;
+    } else if (details.release_date) {
+        return formatReleaseDate(details.release_date, DateSize.LONG);
+    }
+
+    return null;
+};
+
+export { formatReleaseDate, daysAgo, getReleaseDate, DateSize };

--- a/src/helpers/stringFormatUtils.ts
+++ b/src/helpers/stringFormatUtils.ts
@@ -1,10 +1,11 @@
+import { ShowData } from '../types';
+
 /**
  * Extremely basic string pluralize function.
- * If the number provided is one, the string is returns
+ * If the number provided is one, the string is returned
  * If it is any other number, an 's' is appended to the string
- *
  * @param n | value to check
- * @param s | string to update
+ * @param s | singular string to update
  * @returns {string}
  */
 const pluralizeString = (n: number, s: string): string => {
@@ -15,4 +16,26 @@ const pluralizeString = (n: number, s: string): string => {
     }
 };
 
-export { pluralizeString };
+/**
+ * Get runtime if movie
+ * Get number of seasons if TV
+ * @param details | Details of show including runtime
+ */
+const getRuntime = (details: ShowData): string | null => {
+    let str = null;
+    if (details.media_type === 'movie' && details.runtime && details.runtime > 0) {
+        str = `${details.runtime} ${pluralizeString(details.runtime, 'minute')}`;
+    } else if (details.media_type === 'movie') {
+        str = 'No runtime available';
+    }
+
+    if (details.media_type === 'tv' && details.seasons != undefined) {
+        str = `${details.seasons.length} ${pluralizeString(details.seasons.length, 'season')}`;
+    } else if (details.media_type === 'tv') {
+        str = 'No seasons available';
+    }
+
+    return str;
+};
+
+export { pluralizeString, getRuntime };

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -6,6 +6,7 @@ import {
     getTvDetails,
     getTvRecommendations,
     getReleaseDate,
+    getRuntime,
 } from '../helpers';
 import { ShowData } from '../types';
 import { Providers, ShowCarousel, Rating, Button, OfflineSnackbar } from '../components';
@@ -148,26 +149,6 @@ const ShowDetailsScreen: React.FC = () => {
         handler();
     }, [location]);
 
-    /**
-     * Get runtime if movie, seasons if TV and their edge cases
-     */
-    const getRuntime = (): string | null => {
-        let str = null;
-        if (showType === 'movie' && details.runtime && details.runtime > 0) {
-            str = `${details.runtime} minutes`;
-        } else if (showType === 'movie') {
-            str = 'No runtime available';
-        }
-
-        if (showType === 'tv' && details.seasons != undefined) {
-            str = `${details.seasons.length} seasons`;
-        } else if (showType === 'tv') {
-            str = 'No seasons available';
-        }
-
-        return str;
-    };
-
     if (loading) {
         return <ShowDetailsLoader />;
     }
@@ -205,7 +186,7 @@ const ShowDetailsScreen: React.FC = () => {
                             {getReleaseDate(details)}
                         </Typ>
                         <Typ align='left' variant='body2'>
-                            {getRuntime()}
+                            {getRuntime(details)}
                         </Typ>
                         <Typ align='left'>{details.age_rating}</Typ>
                     </div>

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -3,10 +3,9 @@ import { Link, Location, useLocation } from 'react-router-dom';
 import {
     getMovieDetails,
     getMovieRecommendations,
-    formatReleaseDate,
-    DateSize,
     getTvDetails,
     getTvRecommendations,
+    getReleaseDate,
 } from '../helpers';
 import { ShowData } from '../types';
 import { Providers, ShowCarousel, Rating, Button, OfflineSnackbar } from '../components';
@@ -173,31 +172,6 @@ const ShowDetailsScreen: React.FC = () => {
         );
     };
 
-    /**
-     * Displays release date if movie, runtime range if TV. If TV Show is ongoing, displays "YYYY - Present"
-     */
-    const handleReleaseDates = (): JSX.Element | null => {
-        let date: string | null = null;
-        if (!details.release_date || details.release_date.length !== 10) return null;
-
-        if (showType === 'movie') {
-            date = formatReleaseDate(details.release_date, DateSize.LONG);
-        }
-        if (showType === 'tv' && details.next_air_date !== undefined) {
-            date = `${formatReleaseDate(details.release_date, DateSize.SHORT).slice(-4)} - Present`;
-        } else if (details.end_date) {
-            date = `${formatReleaseDate(details.release_date, DateSize.SHORT).slice(
-                -4
-            )} - ${formatReleaseDate(details.end_date, DateSize.SHORT).slice(-4)}`;
-        }
-        if (!date) return null;
-        return (
-            <Typ align='left' data-testid='details-release-date'>
-                {date}
-            </Typ>
-        );
-    };
-
     if (loading) {
         return <ShowDetailsLoader />;
     }
@@ -231,7 +205,9 @@ const ShowDetailsScreen: React.FC = () => {
                         >
                             {details.title}
                         </Typ>
-                        {handleReleaseDates()}
+                        <Typ align='left' data-testid='details-release-date'>
+                            {getReleaseDate(details)}
+                        </Typ>
                         {handleRuntimes()}
                         <Typ align='left'>{details.age_rating}</Typ>
                     </div>

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -172,7 +172,7 @@ const ShowDetailsScreen: React.FC = () => {
         return <ShowDetailsLoader />;
     }
 
-    // TODO: #438 Handle case when no details are ever returned
+    // TODO: #691 Handle case when no details are ever returned
     if (!details) {
         return <p>No details found!</p>;
     }

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -149,27 +149,23 @@ const ShowDetailsScreen: React.FC = () => {
     }, [location]);
 
     /**
-     * Displays runtime if movie, seasons if TV and their edge cases
+     * Get runtime if movie, seasons if TV and their edge cases
      */
-    const handleRuntimes = (): JSX.Element | null => {
-        let str;
+    const getRuntime = (): string | null => {
+        let str = null;
         if (showType === 'movie' && details.runtime && details.runtime > 0) {
             str = `${details.runtime} minutes`;
         } else if (showType === 'movie') {
             str = 'No runtime available';
         }
+
         if (showType === 'tv' && details.seasons != undefined) {
             str = `${details.seasons.length} seasons`;
         } else if (showType === 'tv') {
             str = 'No seasons available';
         }
 
-        if (!str) return null;
-        return (
-            <Typ align='left' variant='body2'>
-                {str}
-            </Typ>
-        );
+        return str;
     };
 
     if (loading) {
@@ -208,7 +204,9 @@ const ShowDetailsScreen: React.FC = () => {
                         <Typ align='left' data-testid='details-release-date'>
                             {getReleaseDate(details)}
                         </Typ>
-                        {handleRuntimes()}
+                        <Typ align='left' variant='body2'>
+                            {getRuntime()}
+                        </Typ>
                         <Typ align='left'>{details.age_rating}</Typ>
                     </div>
                     <Rating


### PR DESCRIPTION
## Description

<!-- Provide a description of the changes made -->
Created unit tests for `daysAgo` and the show details release date and runtime functions.

I found a small bug in the release date function where if a release_date was present on a tv show but no end_date or next_air_date, it would return null. In this case we should return the release date formatted as a single date, as we do with movies.

Other than the note above, this does not change any functionality or UI.

Created #691

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created
