### PR TITLE
Automate TODO script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
       run: npm run compile
     - name: Run ESLint
       run: npx eslint . --ext .ts,.tsx
+    - name: Run todo report
+      run: |
+        npx leasot -x -S --reporter markdown 'src/**/*' > PR_TODO.md
+        git diff --no-index --exit-code TODO.md PR_TODO.md
     - name: Create .env
       run: |
         touch .env

--- a/TODO.md
+++ b/TODO.md
@@ -6,8 +6,8 @@
 | [src/components/Navigation.tsx](src/components/Navigation.tsx#L155) | 155 | Fix deprecated prop |
 | [src/components/Navigation.tsx](src/components/Navigation.tsx#L241) | 241 | Add a transition when search is expanded or collapsed |
 | [src/screens/DiscoverScreen.tsx](src/screens/DiscoverScreen.tsx#L61) | 61 | #613 Dynamic date range |
-| [src/screens/PageNotFoundScreen.tsx](src/screens/PageNotFoundScreen.tsx#L25) | 25 | Implement better error handling |
-| [src/screens/PageNotFoundScreen.tsx](src/screens/PageNotFoundScreen.tsx#L26) | 26 | Handle thrown responses with 'isRouteErrorResponse' |
+| [src/screens/PageNotFoundScreen.tsx](src/screens/PageNotFoundScreen.tsx#L42) | 42 | Implement better error handling |
+| [src/screens/PageNotFoundScreen.tsx](src/screens/PageNotFoundScreen.tsx#L43) | 43 | Handle thrown responses with 'isRouteErrorResponse' |
 | [src/supabase/profiles.ts](src/supabase/profiles.ts#L253) | 253 | #587 Ensure country code is valid |
 | [src/screens/auth/LoginScreen.tsx](src/screens/auth/LoginScreen.tsx#L86) | 86 | We could try to get the AuthApiError type and use 'cause' instead |
-| [src/screens/dashboard/DashboardGalleryScreen.tsx](src/screens/dashboard/DashboardGalleryScreen.tsx#L27) | 27 | If profile does not return after a few seconds, |
+| [src/screens/dashboard/DashboardGalleryScreen.tsx](src/screens/dashboard/DashboardGalleryScreen.tsx#L38) | 38 | If profile does not return after a few seconds, |


### PR DESCRIPTION
## Description

<!-- Provide a description of the changes made -->
Added the todo script to the PR automation. This will not run on pre-commit so you can add TODO comments as you work and not need to update the markdown file. Only once the comments are guaranteed to be left in the code will we require them to be added to the document.

The check is done by running a new TODO report. It then compares that file to the existing one. If there is any difference, the CI will fail.

One minor annoyance is that this will fail when todo comments change lines. So when code is added above a TODO comment the markdown file will need to be updated. In my opinion, this is not the end of the world. It ensures the file is always up to date.

Closes #694 

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created
