### PR TITLE
#578 fix scroll overflow color

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Streamability</title>
   </head>
-  <body class="bg-background text-text">
+  <body class="bg-foreground text-text">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/AppWrapper.tsx
+++ b/src/AppWrapper.tsx
@@ -132,7 +132,7 @@ export default function AppWrapper(): JSX.Element {
                 baseColor={theme.palette.loader.base}
                 highlightColor={theme.palette.loader.highlight}
             >
-                <main className='flex min-h-screen flex-col place-items-center'>
+                <main className='flex min-h-screen flex-col place-items-center bg-background'>
                     <Navigation session={session} switchTheme={themeSwitcher} theme={theme} />
                     <div className='flex flex-auto flex-col items-center text-center w-full'>
                         <Outlet context={{ session, setSession, profile, setProfile }} />


### PR DESCRIPTION
## Description

<!-- Provide a description of the changes made -->
By making the body the color of the footer and the app wrapper the background color, we make the scroll overflow color make the footer and nav and keep the app bg the same.

Closes #578 

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created

## Screenshot

<img width="1137" alt="image" src="https://github.com/Thenlie/Streamability/assets/41388783/6a8cf119-c91e-44e8-a412-a4cb4bd5369e">
