### PR TITLE
add mock for intersection observer

### DIFF
--- a/src/__tests__/screens/SearchResultsScreen.test.tsx
+++ b/src/__tests__/screens/SearchResultsScreen.test.tsx
@@ -21,6 +21,16 @@ const router = createMemoryRouter(routes, {
 });
 
 describe('Search Results Screen', () => {
+    beforeEach(() => {
+        // IntersectionObserver isn't available in test environment
+        const mockIntersectionObserver = vi.fn();
+        mockIntersectionObserver.mockReturnValue({
+            observe: () => null,
+            unobserve: () => null,
+            disconnect: () => null,
+        });
+        window.IntersectionObserver = mockIntersectionObserver;
+    });
     it('search results loader displayed initially when `data` is null', async () => {
         vi.mocked(usePaginatedData).mockReturnValue({
             data: null,


### PR DESCRIPTION
# Description

#951 was merged without running tests since it came from a fork. As such, there was a small bug in the SearchResultsScreen test. This was fixed by mocking the `IntersectionObserver`.

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created
