### PR TITLE
Fix Storybook

### DIFF
--- a/.babelrc.cjs
+++ b/.babelrc.cjs
@@ -1,5 +1,8 @@
-const plugins = [
-    ['babel-plugin-direct-import', { modules: ['@mui/material', '@mui/icons-material'] }],
-];
-
-module.exports = { plugins };
+module.exports = {
+    presets: [
+        '@babel/preset-typescript',
+    ],
+    plugins: [
+        ['babel-plugin-direct-import', { modules: ['@mui/material', '@mui/icons-material'] }],
+    ],
+};

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -16,5 +16,8 @@ const config: StorybookConfig = {
     docs: {
         autodocs: 'tag',
     },
+    typescript: {
+        reactDocgen: 'react-docgen-typescript'
+    }
 };
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-router-dom": "^6.23.1"
       },
       "devDependencies": {
+        "@babel/preset-typescript": "^7.24.7",
         "@inquirer/prompts": "^5.0.6",
         "@storybook/addon-essentials": "^8.1.10",
         "@storybook/addon-interactions": "^8.1.10",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-router-dom": "^6.23.1"
   },
   "devDependencies": {
+    "@babel/preset-typescript": "^7.24.7",
     "@inquirer/prompts": "^5.0.6",
     "@storybook/addon-essentials": "^8.1.10",
     "@storybook/addon-interactions": "^8.1.10",


### PR DESCRIPTION
# Description

Storybook has been broken since updating to v8 a while back. I posted about this in the storybook repo since I could not figure out the issue. https://github.com/storybookjs/storybook/discussions/28350. It turned out to be a small config change that was made required with v8. Adding this in plus a suggested babelrc update. 

This should also unblock all the storybook dependabot PRs. 

## Storybook actually loading

![image](https://github.com/user-attachments/assets/936e6e6f-f685-4d8e-8094-ea043765f099)

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created
