### PR TITLE
mock console logs in tests where they are expected

### DIFF
--- a/src/__tests__/screens/PageNotFoundScreen.test.tsx
+++ b/src/__tests__/screens/PageNotFoundScreen.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { describe, it } from 'vitest';
+import { describe, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 import { routes } from '../../routes';
@@ -8,7 +8,15 @@ const router = createMemoryRouter(routes, {
     initialEntries: ['/asdf'],
 });
 
+// This needs to mock `log` since we transform LOG.error calls into console.log
+const consoleErrorMock = vi.spyOn(console, 'log').mockImplementation(() => {});
+const consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
 describe('Page Not Found Screen', () => {
+    afterAll(() => {
+        consoleErrorMock.mockReset();
+        consoleWarnMock.mockReset();
+    });
     it('renders on an invalid route', async () => {
         render(<RouterProvider router={router} />);
 
@@ -16,5 +24,12 @@ describe('Page Not Found Screen', () => {
         expect(screen.getByAltText('Page not found')).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Return home' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Go Back' })).toBeInTheDocument();
+        expect(consoleErrorMock).toHaveBeenCalledWith(
+            '%c ERROR [PageNotFoundScreen] Not Found',
+            'background: firebrick; color: white'
+        );
+        expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+        expect(consoleWarnMock).toHaveBeenCalledWith('No routes matched location "/asdf" ');
+        expect(consoleWarnMock).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/__tests__/screens/SearchResultsScreen.test.tsx
+++ b/src/__tests__/screens/SearchResultsScreen.test.tsx
@@ -16,6 +16,13 @@ vi.mock('../../hooks', async () => {
     };
 });
 
+// This needs to mock `log` since we transform LOG.error calls into console.log
+const consoleErrorMock = vi.spyOn(console, 'log').mockImplementation(() => {});
+const consoleErrorMsg = [
+    '%c ERROR [SearchResultsHeader] No original data in local storage',
+    'background: firebrick; color: white',
+];
+
 const router = createMemoryRouter(routes, {
     initialEntries: ['/search?q=iron+man'],
 });
@@ -30,6 +37,9 @@ describe('Search Results Screen', () => {
             disconnect: () => null,
         });
         window.IntersectionObserver = mockIntersectionObserver;
+    });
+    afterAll(() => {
+        consoleErrorMock.mockRestore();
     });
     it('search results loader displayed initially when `data` is null', async () => {
         vi.mocked(usePaginatedData).mockReturnValue({
@@ -46,6 +56,8 @@ describe('Search Results Screen', () => {
         const headerText = screen.getByText('Search results for:');
         expect(headerText).toBeInTheDocument();
         expect(within(headerText).getByText('iron man')).toBeInTheDocument();
+        expect(consoleErrorMock).toHaveBeenCalledWith(...consoleErrorMsg);
+        expect(consoleErrorMock).toHaveBeenCalledTimes(1);
     });
 
     it('empty search results displayed when no data is returned', async () => {
@@ -73,6 +85,8 @@ describe('Search Results Screen', () => {
         expect(screen.getByTestId('show-carousel')).toBeInTheDocument();
         const button = screen.getByRole('button', { name: 'Return Home' });
         expect(button).toHaveTextContent('Return Home');
+        expect(consoleErrorMock).toHaveBeenCalledWith(...consoleErrorMsg);
+        expect(consoleErrorMock).toHaveBeenCalledTimes(2);
     });
 
     it('search results gallery displayed when data is returned', async () => {
@@ -90,5 +104,7 @@ describe('Search Results Screen', () => {
         const headerText = screen.getByText('Search results for:');
         expect(headerText).toBeInTheDocument();
         expect(within(headerText).getByText('iron man')).toBeInTheDocument();
+        expect(consoleErrorMock).toHaveBeenCalledWith(...consoleErrorMsg);
+        expect(consoleErrorMock).toHaveBeenCalledTimes(3);
     });
 });


### PR DESCRIPTION
# Description

Mocking console logs in test files where they are expected. This serves two purposes:

1. Removes bloat from the test logs and makes them easier to parse
2. Allows us to `expect` logs to be called with certain messages to ensure our logging works as expected

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created

Closes #937 