### PR TITLE
add dependabot group for @types dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,10 @@ updates:
         patterns:
           - "@storybook*"
           - "storybook*"
+      types:
+        applies-to: version-updates
+        patterns:
+          - "@types/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
# Description

Group all `@types/` dependencies in dependabot PRs. Should help reduce PR noise and keep types as up-to-date as possible.

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [ ] Screenshots added for any UX changes
- [ ] Demos attached for animations/interactions
- [ ] Pointed at proper branch (`develop` not `main`)
- [ ] Assigned PR to yourself
- [ ] Requested review from code owners
- [ ] Relevant labels added (`feature`, `documentation`, etc.)
- [ ] `Closes #<issue-number>` added if this resolves a GitHub issue
- [ ] Branch is up to date with develop, ran `git rebase develop` if necessary
- [ ] All GitHub Actions are passing
- [ ] `npm run todo-ci` ran if any todo comments were created
