### PR TITLE
Remove cast section when no cast list is provided

### DIFF
--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -201,7 +201,7 @@ const ShowDetailsScreen: React.FC = () => {
                     <ProfileButtonSection showId={showId} showType={showType} />
                 </div>
             </section>
-            {details.credits && (
+            {details.credits && details.credits.cast.length > 0 && (
                 <section className='w-full px-6 md:px-12'>
                     <Typ variant='h5'>Cast</Typ>
                     <div className='flex flex-nowrap overflow-x-auto w-full'>


### PR DESCRIPTION
# Description

<!-- Provide a description of the changes made -->
This resolves a bug where the title of the cast list was still displayed when no cast members were present in the data.

## Screenshots

Working cast
<img width="1682" alt="image" src="https://github.com/user-attachments/assets/7206902b-04b8-44f3-a19a-9c8c867f1ee9" />

No cast
<img width="1249" alt="image" src="https://github.com/user-attachments/assets/340ac7f1-f77e-4eed-9214-b6f474a6b790" />

Closes #1067 

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created
