### PR TITLE
Season Screen & Implementation of SeasonCard

### DIFF
--- a/src/__tests__/components/SeasonCard.test.tsx
+++ b/src/__tests__/components/SeasonCard.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { SeasonCard } from '../../components/';
-import { SEASON } from '../constants';
+import { SEASON, TV_DETAIL } from '../constants';
 import { MemoryRouter, Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 import { vi } from 'vitest';
@@ -12,7 +12,7 @@ describe('SeasonCard', () => {
     it('properly renders with all season info and image', () => {
         render(
             <MemoryRouter>
-                <SeasonCard details={SEASON} />
+                <SeasonCard details={SEASON} title={TV_DETAIL.title} />
             </MemoryRouter>
         );
 
@@ -32,7 +32,7 @@ describe('SeasonCard', () => {
     it('properly renders with placeholder when no image is provided', () => {
         render(
             <MemoryRouter>
-                <SeasonCard details={{ ...SEASON, poster_path: '' }} />
+                <SeasonCard details={{ ...SEASON, poster_path: '' }} title={TV_DETAIL.title} />
             </MemoryRouter>
         );
 
@@ -50,7 +50,7 @@ describe('SeasonCard', () => {
 
         render(
             <Router location={history.location} navigator={history}>
-                <SeasonCard details={SEASON} />
+                <SeasonCard details={SEASON} title={TV_DETAIL.title} />
             </Router>
         );
 

--- a/src/__tests__/components/SeasonCard.test.tsx
+++ b/src/__tests__/components/SeasonCard.test.tsx
@@ -1,10 +1,10 @@
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, act } from '@testing-library/react';
 import { SeasonCard } from '../../components/';
-import { SEASON } from '../constants';
+import { SEASON, TV_DETAIL } from '../constants';
 import { MemoryRouter, Router } from 'react-router';
 import { createMemoryHistory } from 'history';
-import { vi } from 'vitest';
+import { pluralizeString } from '../../helpers';
 
 const TMDB_BASE_PATH = 'https://image.tmdb.org/t/p/w500';
 
@@ -12,68 +12,64 @@ describe('SeasonCard', () => {
     it('properly renders with all season info and image', () => {
         render(
             <MemoryRouter>
-                <SeasonCard details={SEASON} />
+                <SeasonCard details={SEASON} showId={TV_DETAIL.id} />
             </MemoryRouter>
         );
 
         expect(screen.getByTestId('season-card-component')).toBeInTheDocument();
         expect(screen.getByText(SEASON.name)).toBeInTheDocument();
         expect(screen.getByText(SEASON.vote_average)).toBeInTheDocument();
-        expect(screen.getByText(SEASON.air_date.slice(0, 4))).toBeInTheDocument();
-        expect(screen.getByText(SEASON.episode_count + ' Episodes')).toBeInTheDocument();
+        expect(screen.getByText(SEASON.air_date!.slice(0, 4))).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                `${SEASON.episode_count} ${pluralizeString(SEASON.episode_count, 'Episode')}`
+            )
+        ).toBeInTheDocument();
         expect(screen.getByText(SEASON.overview)).toBeInTheDocument();
         expect(screen.getByRole('img')).toHaveAttribute('src', TMDB_BASE_PATH + SEASON.poster_path);
         expect(screen.getByRole('link')).toHaveAttribute(
             'href',
-            '/seasons/' + SEASON.season_number
+            `/details/tv/${TV_DETAIL.id}/seasons/${SEASON.season_number}`
         );
     });
-
-    it('properly renders with placeholder poster when no image is provided', () => {
+    it('properly renders with placeholder poster and fallback text for specials seasons', () => {
         render(
             <MemoryRouter>
-                <SeasonCard details={{ ...SEASON, poster_path: '' }} />
+                <SeasonCard
+                    details={{ ...SEASON, poster_path: '', season_number: 0 }}
+                    title={TV_DETAIL.title}
+                    showId={TV_DETAIL.id}
+                />
             </MemoryRouter>
         );
 
         expect(screen.getByTestId('season-card-component')).toBeInTheDocument();
         expect(screen.getByRole('img')).toHaveAttribute('src', '/poster-placeholder.jpeg');
-        expect(screen.getByRole('link')).toHaveAttribute(
-            'href',
-            '/seasons/' + SEASON.season_number
+        expect(
+            screen.getByText(
+                `Special episodes including behind the scenes footage of ${TV_DETAIL.title}.`
+            )
         );
     });
-
-    it('is clickable and navigates to season details screen', () => {
+    it('is clickable and navigates to season details screen', async () => {
         const history = createMemoryHistory();
-        history.push = vi.fn();
+        history.push(`/details/tv/${TV_DETAIL.id}`);
 
         render(
             <Router location={history.location} navigator={history}>
-                <SeasonCard details={SEASON} />
+                <SeasonCard details={SEASON} showId={TV_DETAIL.id} />
             </Router>
         );
 
-        expect(screen.getByTestId('season-card-component')).toBeInTheDocument();
-        expect(screen.getByRole('img')).toHaveAttribute('src', TMDB_BASE_PATH + SEASON.poster_path);
         expect(screen.getByRole('link')).toHaveAttribute(
             'href',
-            '/seasons/' + SEASON.season_number
+            `/details/tv/${TV_DETAIL.id}/seasons/${SEASON.season_number}`
         );
-        fireEvent.click(screen.getByTestId('season-card-component'));
-        expect(history.push).toHaveBeenCalledWith(
-            {
-                hash: '',
-                pathname: '/seasons/' + SEASON.season_number,
-                search: '',
-            },
-            undefined,
-            {
-                preventScrollReset: undefined,
-                relative: undefined,
-                replace: false,
-                state: undefined,
-            }
-        );
+        await act(async () => {
+            fireEvent.click(screen.getByRole('link'));
+            expect(history.location.pathname).toBe(
+                `/details/tv/${TV_DETAIL.id}/seasons/${SEASON.season_number}`
+            );
+        });
     });
 });

--- a/src/__tests__/components/SeasonCard.test.tsx
+++ b/src/__tests__/components/SeasonCard.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { SeasonCard } from '../../components/';
-import { SEASON, TV_DETAIL } from '../constants';
+import { SEASON } from '../constants';
 import { MemoryRouter, Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 import { vi } from 'vitest';
@@ -12,7 +12,7 @@ describe('SeasonCard', () => {
     it('properly renders with all season info and image', () => {
         render(
             <MemoryRouter>
-                <SeasonCard details={SEASON} title={TV_DETAIL.title} />
+                <SeasonCard details={SEASON} />
             </MemoryRouter>
         );
 
@@ -29,10 +29,10 @@ describe('SeasonCard', () => {
         );
     });
 
-    it('properly renders with placeholder when no image is provided', () => {
+    it('properly renders with placeholder poster when no image is provided', () => {
         render(
             <MemoryRouter>
-                <SeasonCard details={{ ...SEASON, poster_path: '' }} title={TV_DETAIL.title} />
+                <SeasonCard details={{ ...SEASON, poster_path: '' }} />
             </MemoryRouter>
         );
 
@@ -44,13 +44,13 @@ describe('SeasonCard', () => {
         );
     });
 
-    it('is clickable and navigates to season detail screen', () => {
+    it('is clickable and navigates to season details screen', () => {
         const history = createMemoryHistory();
         history.push = vi.fn();
 
         render(
             <Router location={history.location} navigator={history}>
-                <SeasonCard details={SEASON} title={TV_DETAIL.title} />
+                <SeasonCard details={SEASON} />
             </Router>
         );
 

--- a/src/__tests__/constants.ts
+++ b/src/__tests__/constants.ts
@@ -64,7 +64,7 @@ export const MOVIE_DETAIL: ShowData = {
             origin_country: 'US',
         },
     ],
-    seasons: null,
+    seasons: undefined,
     end_date: null,
     next_air_date: null,
 };

--- a/src/__tests__/constants.ts
+++ b/src/__tests__/constants.ts
@@ -64,6 +64,25 @@ export const MOVIE_DETAIL: ShowData = {
             origin_country: 'US',
         },
     ],
+    credits: {
+        cast: [
+            {
+                adult: false,
+                gender: 2,
+                id: 3223,
+                known_for_department: 'Acting',
+                name: 'Robert Downey Jr.',
+                original_name: 'Robert Downey Jr.',
+                popularity: 57.084,
+                profile_path: '/im9SAqJPZKEbVZGmjXuLI4O7RvM.jpg',
+                cast_id: 19,
+                character: 'Tony Stark / Iron Man',
+                credit_id: '52fe4311c3a36847f8037ee9',
+                order: 0
+            }
+        ],
+        crew: []
+    },
     seasons: undefined,
     end_date: null,
     next_air_date: null,
@@ -101,6 +120,25 @@ export const TV_DETAIL: ShowData = {
             origin_country: 'US',
         },
     ],
+    credits: {
+        cast: [
+            {
+                adult: false,
+                gender: 2,
+                id: 22970,
+                known_for_department: 'Acting',
+                name: 'Peter Dinklage',
+                original_name: 'Peter Dinklage',
+                popularity: 29.051,
+                profile_path: '/9CAd7wr8QZyIN0E7nm8v1B6WkGn.jpg',
+                cast_id: 0,
+                character: 'Tyrion \'The Halfman\' Lannister',
+                credit_id: '5256c8b219c2956ff6047cd8',
+                order: 0
+            }
+        ],
+        crew: []
+    },
     seasons: [
         {
             air_date: '2010-12-05',

--- a/src/__tests__/screens/SeasonsScreen.test.tsx
+++ b/src/__tests__/screens/SeasonsScreen.test.tsx
@@ -1,10 +1,9 @@
 import '@testing-library/jest-dom';
 import { describe, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, act } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router';
 import { routes } from '../../routes';
 import { getTvDetails } from '../../helpers';
-import { act } from 'react';
 import { TV_DETAIL } from '../constants';
 
 const TMDB_BASE_PATH = 'https://image.tmdb.org/t/p/w500';
@@ -23,7 +22,7 @@ const tvRouter = createMemoryRouter(routes, {
 });
 
 describe('Seasons Screen', () => {
-    it('properly renders applicable TV show data', async () => {
+    it('properly renders TV show and season data', async () => {
         vi.mocked(getTvDetails).mockResolvedValue(TV_DETAIL);
 
         render(<RouterProvider router={tvRouter} />);
@@ -34,6 +33,9 @@ describe('Seasons Screen', () => {
         expect(screen.getByAltText(`${TV_DETAIL.title} poster`)).toHaveAttribute(
             'src',
             TMDB_BASE_PATH + TV_DETAIL.poster_path
+        );
+        expect(screen.getAllByTestId('season-card-component').length).toBe(
+            TV_DETAIL.seasons?.length
         );
     });
     it('properly renders placeholder image if no poster path is provided', async () => {
@@ -53,7 +55,7 @@ describe('Seasons Screen', () => {
 
         await screen.findByTestId('seasons-screen');
         await act(async () => {
-            fireEvent.click(await screen.findByRole('link', { name: 'Back' }));
+            fireEvent.click(await screen.findByRole('link', { name: 'Back to Show Details' }));
         });
         expect(tvRouter.state.location.pathname).toBe(`/details/tv/${TV_DETAIL.id}`);
     });

--- a/src/__tests__/screens/SeasonsScreen.test.tsx
+++ b/src/__tests__/screens/SeasonsScreen.test.tsx
@@ -1,0 +1,69 @@
+import '@testing-library/jest-dom';
+import { describe, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Router, RouterProvider, createMemoryRouter } from 'react-router';
+import { routes } from '../../routes';
+import {
+    getMovieDetails,
+    getMovieRecommendations,
+    getReleaseDate,
+    getRuntime,
+    getTvDetails,
+    getTvRecommendations,
+} from '../../helpers';
+import { act } from 'react';
+import { MOVIE_DETAIL, TRENDING_DATA, TV_DETAIL } from '../constants';
+import { ShowData } from '../../types';
+import { createMemoryHistory } from 'history';
+
+const TMDB_BASE_PATH = 'https://image.tmdb.org/t/p/w500';
+
+vi.mock('../../helpers', async () => {
+    const actual = await vi.importActual('../../helpers');
+
+    return {
+        ...(actual as object),
+        getTvDetails: vi.fn()
+    };
+});
+
+const tvRouter = createMemoryRouter(routes, {
+    initialEntries: [`/details/tv/${TV_DETAIL.id}/seasons`],
+});
+
+describe('Seasons Screen', () => {
+    it('properly renders applicable TV show data', async () => {
+        vi.mocked(getTvDetails).mockResolvedValue(TV_DETAIL);
+
+        render(
+            <RouterProvider router={tvRouter} />
+        );
+
+        await screen.findByTestId('seasons-screen')
+        expect(screen.getByText(TV_DETAIL.title)).toBeInTheDocument();
+        expect(screen.getByText("(" + TV_DETAIL.release_date?.slice(0, 4) + ")"))
+        expect(screen.getByAltText(`${TV_DETAIL.title} poster`)).toHaveAttribute('src', TMDB_BASE_PATH + TV_DETAIL.poster_path);
+    })
+    it('properly renders placeholder image if no poster path is provided', async () => {
+        vi.mocked(getTvDetails).mockResolvedValue({ ...TV_DETAIL, poster_path: null });
+        render(
+            <RouterProvider router={tvRouter} />
+        )
+
+        await screen.findByTestId('seasons-screen')
+        expect(screen.getByAltText(`${TV_DETAIL.title} poster`)).toHaveAttribute('src', '/poster-placeholder.jpeg')
+    })
+    it('properly provides link that navigates back to TV details', async () => {
+        vi.mocked(getTvDetails).mockResolvedValue(TV_DETAIL);
+
+        render(
+            <RouterProvider router={tvRouter} />
+        );
+
+        await screen.findByTestId('seasons-screen')
+        await act(async () => {
+            fireEvent.click(await screen.findByRole('link', { name: 'Back' }));
+        })
+        expect(tvRouter.state.location.pathname).toBe(`/details/tv/${TV_DETAIL.id}`)
+    })
+})

--- a/src/__tests__/screens/SeasonsScreen.test.tsx
+++ b/src/__tests__/screens/SeasonsScreen.test.tsx
@@ -1,20 +1,11 @@
 import '@testing-library/jest-dom';
 import { describe, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { Router, RouterProvider, createMemoryRouter } from 'react-router';
+import { RouterProvider, createMemoryRouter } from 'react-router';
 import { routes } from '../../routes';
-import {
-    getMovieDetails,
-    getMovieRecommendations,
-    getReleaseDate,
-    getRuntime,
-    getTvDetails,
-    getTvRecommendations,
-} from '../../helpers';
+import { getTvDetails } from '../../helpers';
 import { act } from 'react';
-import { MOVIE_DETAIL, TRENDING_DATA, TV_DETAIL } from '../constants';
-import { ShowData } from '../../types';
-import { createMemoryHistory } from 'history';
+import { TV_DETAIL } from '../constants';
 
 const TMDB_BASE_PATH = 'https://image.tmdb.org/t/p/w500';
 
@@ -23,7 +14,7 @@ vi.mock('../../helpers', async () => {
 
     return {
         ...(actual as object),
-        getTvDetails: vi.fn()
+        getTvDetails: vi.fn(),
     };
 });
 
@@ -35,35 +26,35 @@ describe('Seasons Screen', () => {
     it('properly renders applicable TV show data', async () => {
         vi.mocked(getTvDetails).mockResolvedValue(TV_DETAIL);
 
-        render(
-            <RouterProvider router={tvRouter} />
-        );
+        render(<RouterProvider router={tvRouter} />);
 
-        await screen.findByTestId('seasons-screen')
+        await screen.findByTestId('seasons-screen');
         expect(screen.getByText(TV_DETAIL.title)).toBeInTheDocument();
-        expect(screen.getByText("(" + TV_DETAIL.release_date?.slice(0, 4) + ")"))
-        expect(screen.getByAltText(`${TV_DETAIL.title} poster`)).toHaveAttribute('src', TMDB_BASE_PATH + TV_DETAIL.poster_path);
-    })
+        expect(screen.getByText('(' + TV_DETAIL.release_date?.slice(0, 4) + ')'));
+        expect(screen.getByAltText(`${TV_DETAIL.title} poster`)).toHaveAttribute(
+            'src',
+            TMDB_BASE_PATH + TV_DETAIL.poster_path
+        );
+    });
     it('properly renders placeholder image if no poster path is provided', async () => {
         vi.mocked(getTvDetails).mockResolvedValue({ ...TV_DETAIL, poster_path: null });
-        render(
-            <RouterProvider router={tvRouter} />
-        )
+        render(<RouterProvider router={tvRouter} />);
 
-        await screen.findByTestId('seasons-screen')
-        expect(screen.getByAltText(`${TV_DETAIL.title} poster`)).toHaveAttribute('src', '/poster-placeholder.jpeg')
-    })
-    it('properly provides link that navigates back to TV details', async () => {
+        await screen.findByTestId('seasons-screen');
+        expect(screen.getByAltText(`${TV_DETAIL.title} poster`)).toHaveAttribute(
+            'src',
+            '/poster-placeholder.jpeg'
+        );
+    });
+    it('page header properly provides link that navigates back to TV details', async () => {
         vi.mocked(getTvDetails).mockResolvedValue(TV_DETAIL);
 
-        render(
-            <RouterProvider router={tvRouter} />
-        );
+        render(<RouterProvider router={tvRouter} />);
 
-        await screen.findByTestId('seasons-screen')
+        await screen.findByTestId('seasons-screen');
         await act(async () => {
             fireEvent.click(await screen.findByRole('link', { name: 'Back' }));
-        })
-        expect(tvRouter.state.location.pathname).toBe(`/details/tv/${TV_DETAIL.id}`)
-    })
-})
+        });
+        expect(tvRouter.state.location.pathname).toBe(`/details/tv/${TV_DETAIL.id}`);
+    });
+});

--- a/src/__tests__/screens/ShowDetailsScreen.test.tsx
+++ b/src/__tests__/screens/ShowDetailsScreen.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { describe, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router';
 import { routes } from '../../routes';
 import {
@@ -61,9 +61,12 @@ describe('Show Details Screen', () => {
         expect(screen.getByTestId('empty-show-carousel')).toBeInTheDocument();
         expect(screen.getByAltText(MOVIE_DETAIL.title + ' poster')).toBeInTheDocument();
         expect(screen.getByText(MOVIE_DETAIL.title)).toBeInTheDocument();
-        expect(screen.getByText(MOVIE_DETAIL.overview || '')).toBeInTheDocument();
         expect(screen.getByText(getReleaseDate(MOVIE_DETAIL) || '')).toBeInTheDocument();
         expect(screen.getByText(getRuntime(MOVIE_DETAIL) || '')).toBeInTheDocument();
+        expect(screen.getByText(MOVIE_DETAIL.age_rating || '')).toBeInTheDocument();
+        expect(screen.getByTestId('rating-component')).toBeInTheDocument();
+        expect(screen.getByText(MOVIE_DETAIL.overview || '')).toBeInTheDocument();
+        expect(screen.getByTestId('actor-card-component')).toBeInTheDocument();
     });
     it('tv details properly displayed', async () => {
         vi.mocked(getTvDetails).mockResolvedValue(TV_DETAIL);
@@ -75,9 +78,18 @@ describe('Show Details Screen', () => {
         expect(screen.getByTestId('empty-show-carousel')).toBeInTheDocument();
         expect(screen.getByAltText(TV_DETAIL.title + ' poster')).toBeInTheDocument();
         expect(screen.getByText(TV_DETAIL.title)).toBeInTheDocument();
-        expect(screen.getByText(TV_DETAIL.overview || '')).toBeInTheDocument();
         expect(screen.getByText(getReleaseDate(TV_DETAIL) || '')).toBeInTheDocument();
         expect(screen.getByText(getRuntime(TV_DETAIL) || '')).toBeInTheDocument();
+        expect(screen.getByText(TV_DETAIL.age_rating!)).toBeInTheDocument();
+        expect(screen.getByTestId('rating-component')).toBeInTheDocument();
+        expect(screen.getByText(TV_DETAIL.overview || '')).toBeInTheDocument();
+        expect(screen.getByTestId('actor-card-component')).toBeInTheDocument();
+        expect(screen.getByTestId('season-card-component')).toBeInTheDocument();
+        await act(async () => {
+            fireEvent.click(await screen.findByRole('link', { name: 'View All Seasons' }));
+            expect(tvRouter.state.location.pathname).toBe(`/details/tv/${TV_DETAIL.id}/seasons`);
+        });
+        tvRouter.state.location.pathname = `/details/tv/${TV_DETAIL.id}}`;
     });
     it('shows recommendation carousel when recommendation data is returned', async () => {
         vi.mocked(getMovieDetails).mockResolvedValue(MOVIE_DETAIL);

--- a/src/components/SeasonCard.tsx
+++ b/src/components/SeasonCard.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router';
 
 interface SeasonCardProps {
     details: Season;
+    title: string;
 }
 
 /**
@@ -12,7 +13,8 @@ interface SeasonCardProps {
  * @param details | Season details
  * @returns {JSX.Element}
  */
-const SeasonCard: React.FC<SeasonCardProps> = ({ details }): JSX.Element => {
+const SeasonCard: React.FC<SeasonCardProps> = ({ details, title }): JSX.Element => {
+    console.log(details);
     return (
         <Link
             data-testid='season-card-component'
@@ -33,7 +35,7 @@ const SeasonCard: React.FC<SeasonCardProps> = ({ details }): JSX.Element => {
                         ? `https://image.tmdb.org/t/p/w500${details.poster_path}`
                         : '/poster-placeholder.jpeg'
                 }
-                alt={details.name}
+                alt={details.name + " poster"}
             />
 
             <div className='flex flex-col max-h-[270px] p-2 sm:p-4 max-w-[1200px]'>
@@ -44,9 +46,11 @@ const SeasonCard: React.FC<SeasonCardProps> = ({ details }): JSX.Element => {
                     {details.name}
                 </Typ>
                 <div className='flex justify-around sm:justify-start sm:py-1'>
-                    <Typ className='hidden sm:inline pr-4'>{details.vote_average}</Typ>
-                    <Typ className='sm:px-4'>{details.air_date.slice(0, 4)}</Typ>
-                    <Typ className='sm:px-4'>{details.episode_count} Episodes</Typ>
+                    {details.season_number != 0 && details.air_date &&
+                        <Typ className='hidden sm:inline pr-4'>{details.vote_average}</Typ>
+                    }
+                    <Typ className='sm:pr-4'>{details.air_date ? details.air_date.slice(0, 4) : '-'}</Typ>
+                    <Typ className='sm:pr-4'>{details.episode_count} Episodes</Typ>
                 </div>
                 <div className='hidden sm:block'>
                     <Typ
@@ -59,7 +63,7 @@ const SeasonCard: React.FC<SeasonCardProps> = ({ details }): JSX.Element => {
                             WebkitBoxOrient: 'vertical',
                         }}
                     >
-                        {details.overview}
+                        {details.season_number != 0 ? details.overview : `Special episodes including behind the scenes footage of ${title}.`}
                     </Typ>
                 </div>
             </div>

--- a/src/components/SeasonCard.tsx
+++ b/src/components/SeasonCard.tsx
@@ -1,10 +1,12 @@
 import { Season } from '../types';
 import CardMedia from '@mui/material/CardMedia';
 import { default as Typ } from '@mui/material/Typography';
-import { Link, Location, useLocation } from 'react-router';
+import { Link } from 'react-router';
+import { pluralizeString } from '../helpers';
 
 interface SeasonCardProps {
     details: Season;
+    showId: number;
     title?: string;
 }
 
@@ -13,18 +15,12 @@ interface SeasonCardProps {
  * @param details | Season details
  * @returns {JSX.Element}
  */
-const SeasonCard: React.FC<SeasonCardProps> = ({ details, title }): JSX.Element => {
-    const location: Location = useLocation();
-    const showId = parseInt(location.pathname.split('/')[3]);
+const SeasonCard: React.FC<SeasonCardProps> = ({ details, title, showId }): JSX.Element => {
     return (
         <Link
             data-testid='season-card-component'
             className='my-3 flex flex-col sm:flex-row sm:rounded-md max-w-[180px] sm:max-w-none w-full bg-foreground rounded-t-md'
-            to={
-                location.pathname == `/details/tv/${showId}`
-                    ? `./seasons/${details.season_number}`
-                    : `./${details.season_number}`
-            }
+            to={`/details/tv/${showId}/seasons/${details.season_number}`}
         >
             <CardMedia
                 component='img'
@@ -57,7 +53,7 @@ const SeasonCard: React.FC<SeasonCardProps> = ({ details, title }): JSX.Element 
                     <Typ className='sm:pr-4'>
                         {details.air_date ? details.air_date.slice(0, 4) : '-'}
                     </Typ>
-                    <Typ className='sm:pr-4'>{details.episode_count} Episodes</Typ>
+                    <Typ className='sm:pr-4'>{`${details.episode_count} ${pluralizeString(details.episode_count, 'Episode')}`}</Typ>
                 </div>
                 <div className='hidden sm:block'>
                     <Typ

--- a/src/components/SeasonCard.tsx
+++ b/src/components/SeasonCard.tsx
@@ -1,11 +1,11 @@
 import { Season } from '../types';
 import CardMedia from '@mui/material/CardMedia';
 import { default as Typ } from '@mui/material/Typography';
-import { Link } from 'react-router';
+import { Link, Location, useLocation } from 'react-router';
 
 interface SeasonCardProps {
     details: Season;
-    title: string;
+    title?: string;
 }
 
 /**
@@ -14,12 +14,17 @@ interface SeasonCardProps {
  * @returns {JSX.Element}
  */
 const SeasonCard: React.FC<SeasonCardProps> = ({ details, title }): JSX.Element => {
-    console.log(details);
+    const location: Location = useLocation();
+    const showId = parseInt(location.pathname.split('/')[3]);
     return (
         <Link
             data-testid='season-card-component'
             className='my-3 flex flex-col sm:flex-row sm:rounded-md max-w-[180px] sm:max-w-none w-full bg-foreground rounded-t-md'
-            to={`./${details.season_number}`}
+            to={
+                location.pathname == `/details/tv/${showId}`
+                    ? `./seasons/${details.season_number}`
+                    : `./${details.season_number}`
+            }
         >
             <CardMedia
                 component='img'
@@ -35,10 +40,10 @@ const SeasonCard: React.FC<SeasonCardProps> = ({ details, title }): JSX.Element 
                         ? `https://image.tmdb.org/t/p/w500${details.poster_path}`
                         : '/poster-placeholder.jpeg'
                 }
-                alt={details.name + " poster"}
+                alt={details.name + ' poster'}
             />
 
-            <div className='flex flex-col max-h-[270px] p-2 sm:p-4 max-w-[1200px]'>
+            <div className='flex flex-col max-h-[270px] p-2 sm:p-4'>
                 <Typ
                     className='sm:text-left sm:py-1 hover:text-blue-500 cursor-pointer'
                     fontWeight={'bold'}
@@ -46,10 +51,12 @@ const SeasonCard: React.FC<SeasonCardProps> = ({ details, title }): JSX.Element 
                     {details.name}
                 </Typ>
                 <div className='flex justify-around sm:justify-start sm:py-1'>
-                    {details.season_number != 0 && details.air_date &&
+                    {details.season_number != 0 && details.air_date && (
                         <Typ className='hidden sm:inline pr-4'>{details.vote_average}</Typ>
-                    }
-                    <Typ className='sm:pr-4'>{details.air_date ? details.air_date.slice(0, 4) : '-'}</Typ>
+                    )}
+                    <Typ className='sm:pr-4'>
+                        {details.air_date ? details.air_date.slice(0, 4) : '-'}
+                    </Typ>
                     <Typ className='sm:pr-4'>{details.episode_count} Episodes</Typ>
                 </div>
                 <div className='hidden sm:block'>
@@ -63,7 +70,9 @@ const SeasonCard: React.FC<SeasonCardProps> = ({ details, title }): JSX.Element 
                             WebkitBoxOrient: 'vertical',
                         }}
                     >
-                        {details.season_number != 0 ? details.overview : `Special episodes including behind the scenes footage of ${title}.`}
+                        {details.season_number != 0
+                            ? details.overview
+                            : `Special episodes including behind the scenes footage of ${title}.`}
                     </Typ>
                 </div>
             </div>

--- a/src/components/SeasonCard.tsx
+++ b/src/components/SeasonCard.tsx
@@ -16,15 +16,15 @@ const SeasonCard: React.FC<SeasonCardProps> = ({ details }): JSX.Element => {
     return (
         <Link
             data-testid='season-card-component'
-            className='m-3 flex flex-col sm:flex-row bg-foreground rounded-t-md sm:rounded-md'
-            to={`seasons/${details.season_number}`}
+            className='my-3 flex flex-col sm:flex-row sm:rounded-md max-w-[180px] sm:max-w-none w-full bg-foreground rounded-t-md'
+            to={`./${details.season_number}`}
         >
             <CardMedia
                 component='img'
-                className='rounded-sm w-full'
+                className='rounded-sm'
                 sx={{
                     boxShadow: 5,
-                    minWidth: 180,
+                    width: 180,
                     maxHeight: 270,
                     '&:hover': { opacity: 0.8 },
                 }}

--- a/src/helpers/__tests__/constants.ts
+++ b/src/helpers/__tests__/constants.ts
@@ -392,3 +392,106 @@ export const SHOW_DATA_ARRAY: ShowData[] = [
         genre_ids: [16],
     },
 ];
+
+export const SEASONS_VALID: Season[] = [
+    {
+        air_date: '2013-12-02',
+        episode_count: 11,
+        id: 60059,
+        name: 'Season 1',
+        overview:
+            'Rick and Morty visit a pawn shop in space, encounter various alternate and virtual realities, and meet the devil at his antique shop.',
+        poster_path: '/h9RUEsA6BROWcg0QF6ngNPX5FFh.jpg',
+        season_number: 1,
+        vote_average: 8,
+    },
+    {
+        air_date: '2015-07-26',
+        episode_count: 10,
+        id: 66738,
+        name: 'Season 2',
+        overview:
+            'After Rick and Morty decided to unfreeze time, they must deal with alien parasites, alternate Jerrys and a decaying, possibly non-existent dimension.',
+        poster_path: '/zkhGdE29umuKwa6u6mm7e4cXvYY.jpg',
+        season_number: 2,
+        vote_average: 8.3,
+    },
+    {
+        air_date: '2017-04-01',
+        episode_count: 10,
+        id: 86926,
+        name: 'Season 3',
+        overview:
+            'Rick and Morty travel to Atlantis and take some time to relax, plus Rick turns himself into a pickle and faces off against the president.',
+        poster_path: '/7kP0ykqRPyY5anbCOMlR1PtLj8Y.jpg',
+        season_number: 3,
+        vote_average: 8.2,
+    },
+    {
+        air_date: '2019-11-10',
+        episode_count: 10,
+        id: 128112,
+        name: 'Season 4',
+        overview:
+            'Everything and nothing makes sense when bizarre genius Rick and his grandson Morty take more interdimensional journeys that bend time and space.',
+        poster_path: '/87abbwoOfm5MMCWoFewN8pNGZxW.jpg',
+        season_number: 4,
+        vote_average: 7.8,
+    },
+    {
+        air_date: '2021-06-20',
+        episode_count: 10,
+        id: 188470,
+        name: 'Season 5',
+        overview:
+            'Hold onto your butts — it’s season five, baby! Rick, Morty and the fam are back with ten all-new episodes that consume unheld butts. Sex, romance, testicle monsters… a guy named Mr. Nimbus… It’s everything you want, get your butt ready!',
+        poster_path: '/8KdHdOAP8mM4TmykkXnpr6qkyUU.jpg',
+        season_number: 5,
+        vote_average: 7.2,
+    },
+    {
+        air_date: '2022-09-04',
+        episode_count: 10,
+        id: 302503,
+        name: 'Season 6',
+        overview:
+            'It’s season six and Rick and Morty are back! Pick up where we left them, worse for wear and down on their luck. Will they manage to bounce back for more adventures? Or will they get swept up in an ocean of piss! Who knows?! Piss! Family! Intrigue! A bunch of dinosaurs! More piss! Another can’t miss season of your favorite show.',
+        poster_path: '/cvhNj9eoRBe5SxjCbQTkh05UP5K.jpg',
+        season_number: 6,
+        vote_average: 7.5,
+    },
+    {
+        air_date: '2023-10-15',
+        episode_count: 10,
+        id: 354041,
+        name: 'Season 7',
+        overview:
+            "Rick and Morty are back and sounding more like themselves than ever! It's season seven, and the possibilities are endless: what's up with Jerry? EVIL Summer?! And will they ever go back to the high school?! Maybe not! But let's find out! There's probably less piss than last season. \"Rick and Morty,\" 100 years! Or at least until season 10!",
+        poster_path: '/OXy96OFiLDZIz9jT4Byxk1Hk6b.jpg',
+        season_number: 7,
+        vote_average: 7.3,
+    },
+];
+
+export const SEASON_INVALID: Season[] = [
+    {
+        air_date: '2016-10-25',
+        episode_count: 35,
+        id: 106178,
+        name: 'Specials',
+        overview: '',
+        poster_path: '/3my0MrOKCSYMw8VfLiiM9k00bdF.jpg',
+        season_number: 0,
+        vote_average: 0,
+    },
+    {
+        air_date: null,
+        episode_count: 0,
+        id: 424080,
+        name: 'Season 8',
+        overview: '',
+        poster_path: null,
+        season_number: 8,
+        vote_average: 0,
+    },
+];

--- a/src/helpers/__tests__/validation.test.ts
+++ b/src/helpers/__tests__/validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { validateCountry, validateCountryCode } from '../validationUtils';
+import { validateCountry, validateCountryCode, validateSeasons } from '../validationUtils';
+import { SEASONS_VALID, SEASON_INVALID } from './constants';
 
 describe('validateCountryCode', () => {
     it('properly validates valid country codes', () => {
@@ -28,5 +29,22 @@ describe('validateCountryC', () => {
         expect(validateCountry('UK')).toBe(false);
         expect(validateCountry('Russsia')).toBe(false);
         expect(validateCountry('invalid')).toBe(false);
+    });
+});
+
+describe('validateSeasons', () => {
+    it('returns provided array if no invalid seasons are found', () => {
+        expect(validateSeasons(SEASONS_VALID).length).toBe(SEASONS_VALID.length);
+    });
+    it('properly removes specials seasons, unreleased seasons, or both', () => {
+        expect(validateSeasons([...SEASONS_VALID, SEASON_INVALID[0]]).length).toBe(
+            SEASONS_VALID.length
+        );
+        expect(validateSeasons([...SEASONS_VALID, SEASON_INVALID[1]]).length).toBe(
+            SEASONS_VALID.length
+        );
+        expect(
+            validateSeasons([...SEASONS_VALID, SEASON_INVALID[0], SEASON_INVALID[1]]).length
+        ).toBe(SEASONS_VALID.length);
     });
 });

--- a/src/helpers/showTypeUtils.ts
+++ b/src/helpers/showTypeUtils.ts
@@ -110,8 +110,7 @@ const convertDetailsToShowType = (
             };
         }),
         seasons: mediaType === 'movie' ? null : (data as TvDetailsData).seasons,
-        end_date:
-            mediaType === 'movie' ? null : (data as TvDetailsData).last_episode_to_air.air_date,
+        end_date: mediaType === 'movie' ? null : (data as TvDetailsData).last_episode_to_air?.air_date,
         next_air_date:
             mediaType === 'movie' ? null : (data as TvDetailsData).next_episode_to_air?.air_date,
     };

--- a/src/helpers/stringFormatUtils.ts
+++ b/src/helpers/stringFormatUtils.ts
@@ -1,4 +1,5 @@
 import { ShowData } from '../types';
+import { validateSeasons } from './';
 
 /**
  * Extremely basic string pluralize function.
@@ -30,7 +31,8 @@ const getRuntime = (details: ShowData): string | null => {
     }
 
     if (details.media_type === 'tv' && details.seasons != undefined) {
-        str = `${details.seasons.length} ${pluralizeString(details.seasons.length, 'season')}`;
+        const validSeasons = validateSeasons(details.seasons);
+        str = `${validSeasons.length} ${pluralizeString(validSeasons.length, 'season')}`;
     } else if (details.media_type === 'tv') {
         str = 'No seasons available';
     }

--- a/src/helpers/validationUtils.ts
+++ b/src/helpers/validationUtils.ts
@@ -1,3 +1,4 @@
+import { Season } from '../types';
 import { COUNTRIES } from './constants';
 
 /**
@@ -23,4 +24,14 @@ const validateCountry = (country: string): boolean => {
 
 const emailRegex = /^([\w.+-]+)@([\w-]+\.)+([\w]{2,})$/gm;
 
-export { validateCountryCode, validateCountry, emailRegex };
+/**
+ * Returns valid list of seasons by removing untraditional entries provided by TMDB
+ * I.E. 'Specials' and unreleased seasons
+ * @param seasons
+ * @returns {Season[]}
+ */
+const validateSeasons = (seasons: Season[]): Season[] => {
+    return seasons.filter((item) => item.season_number != 0 && item.air_date);
+};
+
+export { validateCountryCode, validateCountry, emailRegex, validateSeasons };

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -13,7 +13,7 @@ import {
     DashboardGalleryScreen,
     DashboardLayout,
     ActorDetailScreen,
-    SeasonsScreen
+    SeasonsScreen,
 } from './screens';
 import { loader as searchLoader } from './screens/search_results/SearchResultsScreen';
 import { loader as dashGalleryLoader } from './screens/dashboard/DashboardGalleryScreen';
@@ -93,7 +93,7 @@ export const routes: RouteObject[] = [
                     },
                     {
                         path: 'tv/:id/seasons',
-                        element: <SeasonsScreen />
+                        element: <SeasonsScreen />,
                     },
                     {
                         path: 'actor/:id',

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -13,6 +13,7 @@ import {
     DashboardGalleryScreen,
     DashboardLayout,
     ActorDetailScreen,
+    SeasonsScreen
 } from './screens';
 import { loader as searchLoader } from './screens/search_results/SearchResultsScreen';
 import { loader as dashGalleryLoader } from './screens/dashboard/DashboardGalleryScreen';
@@ -89,6 +90,10 @@ export const routes: RouteObject[] = [
                     {
                         path: 'tv/:id',
                         element: <ShowDetailsScreen />,
+                    },
+                    {
+                        path: 'tv/:id/seasons',
+                        element: <SeasonsScreen />
                     },
                     {
                         path: 'actor/:id',

--- a/src/screens/SeasonsScreen.tsx
+++ b/src/screens/SeasonsScreen.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { useLocation, Location, Link } from "react-router";
+import { Season, ShowData } from "../types";
+import { getTvDetails } from "../helpers";
+import { SeasonCard, SeasonCardLoader } from "../components";
+import { default as Typ } from '@mui/material/Typography';
+import { CardMedia } from "@mui/material";
+
+const SeasonsScreen: React.FC = (): JSX.Element => {
+    const location: Location = useLocation();
+    const showId = parseInt(location.pathname.split('/')[3]);
+    const [details, setDetails] = useState<ShowData>(
+        location.state ? location.state.details : null
+    );
+    // check if details is passed through router
+    const [loading, setLoading] = useState(details ? false : true);
+
+    useEffect(() => {
+        const handler = async () => {
+            const tvDetails = await getTvDetails(showId);
+            setDetails(tvDetails);
+            setLoading(false);
+        }
+        // check if details is passed through router
+        if (!details) handler();
+    }, [location])
+
+    console.log(details);
+    if (loading) {
+        return <SeasonCardLoader count={5} />
+    }
+
+    return (
+        <section className="m-6 flex items-center sm:items-start flex-col max-w-[1380px]">
+            <div className="mb-3 flex flex-col items-center sm:flex-row">
+                <CardMedia
+                    component='img'
+                    className='rounded-sm'
+                    sx={{
+                        boxShadow: 5,
+                        width: 58,
+                        height: 87,
+                        '&:hover': { opacity: 0.8 },
+                    }}
+                    image={
+                        details.poster_path
+                            ? `https://image.tmdb.org/t/p/w500${details.poster_path}`
+                            : '/poster-placeholder.jpeg'
+                    }
+                    alt={details.title}
+                />
+                <div className="flex flex-col sm:items-start">
+                    <div className="flex flex-col sm:flex-row items-center">
+                        <Typ className="sm:pl-2" fontWeight={'bold'} variant='h4'>{details.title}</Typ>
+                        <Typ className="sm:pl-2">{"(" + details.release_date?.slice(0, 4) + ")"}</Typ>
+                    </div>
+                    <Link className="sm:pl-2" to={`/details/tv/${details.id}`}>Back</Link>
+                </div>
+            </div>
+
+            {details.seasons?.map((item, i) => (
+                <SeasonCard details={item} key={i} />
+            ))}
+        </section>
+    )
+}
+
+export default SeasonsScreen;

--- a/src/screens/SeasonsScreen.tsx
+++ b/src/screens/SeasonsScreen.tsx
@@ -1,18 +1,20 @@
-import { useEffect, useState } from "react";
-import { useLocation, Location, Link } from "react-router";
-import { Season, ShowData } from "../types";
-import { getTvDetails } from "../helpers";
-import { SeasonCard, SeasonCardLoader } from "../components";
+import { useEffect, useState } from 'react';
+import { useLocation, Location, Link } from 'react-router';
+import { ShowData } from '../types';
+import { getTvDetails } from '../helpers';
+import { SeasonCard, SeasonCardLoader } from '../components';
 import { default as Typ } from '@mui/material/Typography';
-import { CardMedia } from "@mui/material";
+import { CardMedia } from '@mui/material';
 
+/**
+ * Screen to render all of a TV Show's Seasons
+ */
 const SeasonsScreen: React.FC = (): JSX.Element => {
     const location: Location = useLocation();
     const showId = parseInt(location.pathname.split('/')[3]);
     const [details, setDetails] = useState<ShowData>(
         location.state ? location.state.details : null
     );
-    // check if details is passed through router
     const [loading, setLoading] = useState(details ? false : true);
 
     useEffect(() => {
@@ -20,18 +22,20 @@ const SeasonsScreen: React.FC = (): JSX.Element => {
             const tvDetails = await getTvDetails(showId);
             setDetails(tvDetails);
             setLoading(false);
-        }
-        // check if details is passed through router
+        };
         if (!details) handler();
-    }, [location])
+    }, [location]);
 
     if (loading) {
-        return <SeasonCardLoader count={5} />
+        return <SeasonCardLoader count={5} />;
     }
 
     return (
-        <section data-testid='seasons-screen' className="m-6 flex items-center sm:items-start flex-col max-w-[1380px]">
-            <div className="mb-3 flex flex-col items-center sm:flex-row">
+        <section
+            data-testid='seasons-screen'
+            className='m-6 flex items-center sm:items-start flex-col w-[70svw] max-w-[1380px]'
+        >
+            <div className='mb-3 flex flex-col sm:flex-row items-center'>
                 <CardMedia
                     component='img'
                     className='rounded-sm'
@@ -46,14 +50,24 @@ const SeasonsScreen: React.FC = (): JSX.Element => {
                             ? `https://image.tmdb.org/t/p/w500${details.poster_path}`
                             : '/poster-placeholder.jpeg'
                     }
-                    alt={details.title + " poster"}
+                    alt={details.title + ' poster'}
                 />
-                <div className="flex flex-col sm:items-start">
-                    <div className="flex flex-col sm:flex-row items-center">
-                        <Typ className="sm:pl-2" fontWeight={'bold'} variant='h4'>{details.title}</Typ>
-                        <Typ className="sm:pl-2">{"(" + details.release_date?.slice(0, 4) + ")"}</Typ>
+                <div className='flex flex-col sm:items-start'>
+                    <div className='flex flex-col sm:flex-row items-center'>
+                        <Typ className='sm:pl-2' fontWeight={'bold'} variant='h4'>
+                            {details.title}
+                        </Typ>
+                        <Typ className='sm:pl-2'>
+                            {'(' + details.release_date?.slice(0, 4) + ')'}
+                        </Typ>
                     </div>
-                    <Link className="sm:pl-2" to={`/details/tv/${details.id}`}>Back</Link>
+                    <Link
+                        className='sm:pl-2 hover:text-blue-500 cursor-pointer'
+                        to={`/details/tv/${details.id}`}
+                        state={{ details: details }}
+                    >
+                        Back
+                    </Link>
                 </div>
             </div>
 
@@ -61,7 +75,7 @@ const SeasonsScreen: React.FC = (): JSX.Element => {
                 <SeasonCard key={i} details={item} title={details.title} />
             ))}
         </section>
-    )
-}
+    );
+};
 
 export default SeasonsScreen;

--- a/src/screens/SeasonsScreen.tsx
+++ b/src/screens/SeasonsScreen.tsx
@@ -66,13 +66,13 @@ const SeasonsScreen: React.FC = (): JSX.Element => {
                         to={`/details/tv/${details.id}`}
                         state={{ details: details }}
                     >
-                        Back
+                        Back to Show Details
                     </Link>
                 </div>
             </div>
 
             {details.seasons?.map((item, i) => (
-                <SeasonCard key={i} details={item} title={details.title} />
+                <SeasonCard key={i} details={item} title={details.title} showId={details.id} />
             ))}
         </section>
     );

--- a/src/screens/SeasonsScreen.tsx
+++ b/src/screens/SeasonsScreen.tsx
@@ -25,13 +25,12 @@ const SeasonsScreen: React.FC = (): JSX.Element => {
         if (!details) handler();
     }, [location])
 
-    console.log(details);
     if (loading) {
         return <SeasonCardLoader count={5} />
     }
 
     return (
-        <section className="m-6 flex items-center sm:items-start flex-col max-w-[1380px]">
+        <section data-testid='seasons-screen' className="m-6 flex items-center sm:items-start flex-col max-w-[1380px]">
             <div className="mb-3 flex flex-col items-center sm:flex-row">
                 <CardMedia
                     component='img'
@@ -47,7 +46,7 @@ const SeasonsScreen: React.FC = (): JSX.Element => {
                             ? `https://image.tmdb.org/t/p/w500${details.poster_path}`
                             : '/poster-placeholder.jpeg'
                     }
-                    alt={details.title}
+                    alt={details.title + " poster"}
                 />
                 <div className="flex flex-col sm:items-start">
                     <div className="flex flex-col sm:flex-row items-center">
@@ -59,7 +58,7 @@ const SeasonsScreen: React.FC = (): JSX.Element => {
             </div>
 
             {details.seasons?.map((item, i) => (
-                <SeasonCard details={item} key={i} />
+                <SeasonCard key={i} details={item} title={details.title} />
             ))}
         </section>
     )

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -233,9 +233,12 @@ const ShowDetailsScreen: React.FC = () => {
             {details.seasons && (
                 <section className='flex flex-col items-center sm:items-start my-6 w-[65svw] max-w-[1090px]'>
                     <Typ className='sm:px-1' variant='h5'>
-                        Last Season
+                        Latest Season
                     </Typ>
-                    <SeasonCard details={validateSeasons(details.seasons).slice(-1)[0]} />
+                    <SeasonCard
+                        details={validateSeasons(details.seasons).slice(-1)[0]}
+                        showId={details.id}
+                    />
                     <Link
                         className='sm:px-1 mt-3 hover:text-blue-500 cursor-pointer'
                         to={'seasons'}

--- a/src/screens/ShowDetailsScreen.tsx
+++ b/src/screens/ShowDetailsScreen.tsx
@@ -7,21 +7,31 @@ import {
     getTvRecommendations,
     getReleaseDate,
     getRuntime,
+    validateSeasons,
 } from '../helpers';
-import { ShowData } from '../types';
-import { Providers, ShowCarousel, Rating, Button, OfflineSnackbar, ActorCard } from '../components';
-import Tooltip from '@mui/material/Tooltip';
-import Typ from '@mui/material/Typography';
-import { ShowDetailsLoader } from './loaders';
 import { useProfileContext, useIsInProfileArray, useProfileActions } from '../hooks';
-import AddToQueue from '@mui/icons-material/AddToQueue';
-import Cancel from '@mui/icons-material/Cancel';
-import CheckCircle from '@mui/icons-material/CheckCircle';
-import Favorite from '@mui/icons-material/Favorite';
-import HeartBroken from '@mui/icons-material/HeartBroken';
-import PersonAddAltRounded from '@mui/icons-material/PersonAddAltRounded';
-import RemoveFromQueue from '@mui/icons-material/RemoveFromQueue';
+import { ShowData } from '../types';
+import {
+    Providers,
+    ShowCarousel,
+    Rating,
+    Button,
+    OfflineSnackbar,
+    ActorCard,
+    SeasonCard,
+} from '../components';
+import { ShowDetailsLoader } from './loaders';
 import EmptyShowDetailsScreen from './EmptyShowDetailsScreen';
+import { Tooltip, Typography as Typ } from '@mui/material';
+import {
+    AddToQueue,
+    Cancel,
+    CheckCircle,
+    Favorite,
+    HeartBroken,
+    PersonAddAltRounded,
+    RemoveFromQueue,
+} from '@mui/icons-material';
 
 /**
  * Buttons to alter the show in a logged in users profile.
@@ -132,17 +142,16 @@ const ShowDetailsScreen: React.FC = () => {
 
     useEffect(() => {
         const handler = async () => {
-            setLoading(true);
             if (showType === 'movie') {
                 const movieDetails = await getMovieDetails(showId);
                 setDetails(movieDetails);
                 const recommendation = await getMovieRecommendations(showId);
-                if (recommendation) setRecommendation(recommendation);
+                setRecommendation(recommendation);
             } else {
                 const tvDetails = await getTvDetails(showId);
                 setDetails(tvDetails);
                 const recommendation = await getTvRecommendations(showId);
-                if (recommendation) setRecommendation(recommendation);
+                setRecommendation(recommendation);
             }
             setLoading(false);
         };
@@ -221,7 +230,22 @@ const ShowDetailsScreen: React.FC = () => {
                     </div>
                 </section>
             )}
-            <section className='py-8'>
+            {details.seasons && (
+                <section className='flex flex-col items-center sm:items-start my-6 w-[65svw] max-w-[1090px]'>
+                    <Typ className='sm:px-1' variant='h5'>
+                        Last Season
+                    </Typ>
+                    <SeasonCard details={validateSeasons(details.seasons).slice(-1)[0]} />
+                    <Link
+                        className='sm:px-1 mt-3 hover:text-blue-500 cursor-pointer'
+                        to={'seasons'}
+                        state={{ details: details }}
+                    >
+                        View All Seasons
+                    </Link>
+                </section>
+            )}
+            <section className='my-8'>
                 <ShowCarousel
                     data={recommendations}
                     fallbackText={carouselFallbackText}

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -8,6 +8,7 @@ import FeaturedSearchScreen from './FeaturedSearchScreen';
 import PageNotFoundScreen from './PageNotFoundScreen';
 import ShowDetailsScreen from './ShowDetailsScreen';
 import ActorDetailScreen from './ActorDetailScreen';
+import SeasonsScreen from './SeasonsScreen';
 
 export * from './auth';
 export * from './dashboard';
@@ -20,4 +21,5 @@ export {
     PageNotFoundScreen,
     ShowDetailsScreen,
     DiscoverDetailScreen,
+    SeasonsScreen
 };

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -21,5 +21,5 @@ export {
     PageNotFoundScreen,
     ShowDetailsScreen,
     DiscoverDetailScreen,
-    SeasonsScreen
+    SeasonsScreen,
 };

--- a/src/stories/components/SeasonCard.stories.ts
+++ b/src/stories/components/SeasonCard.stories.ts
@@ -29,5 +29,6 @@ type Story = StoryObj<typeof meta>;
 export const Season: Story = {
     args: {
         details: SEASON,
+        showId: SEASON.show_id,
     },
 };

--- a/src/types/tmdb/show.ts
+++ b/src/types/tmdb/show.ts
@@ -90,12 +90,12 @@ export interface ShowProviders {
 }
 
 export interface Season {
-    air_date: string;
+    air_date: string | null;
     episode_count: number;
     id: number;
     name: string;
     overview: string;
-    poster_path: string;
+    poster_path: string | null;
     season_number: number;
     vote_average: number;
 }


### PR DESCRIPTION
# Description

New screen to display Seasons for a TV Show at the route `/details/tv/:id/seasons`. This includes rendering the newly made `SeasonCard` component on `ShowDetailsScreen`. Closes #1134 

# Pitfalls

Because the displayed data on the `SeasonsScreen` is also provided by the `getTvDetails` request that is made on `ShowDetailsScreen`, data on the `SeasonsScreen` is conditionally requested. If users navigate to the Seasons screen from `ShowDetailsScreen`, data from `ShowDetailsScreen` is passed through the router to prevent unnecessary requests.

On the same note, `SeasonsScreen` is also prepared to operate similarly if the user navigates back to `ShowDetailsScreen`. However, due to `ShowDetailsScreen` making multiple requests beyond show details, it does not make use of it. Created #1164 

# Tests

This PR includes several new tests as well as modifications to existing tests. Most notably, `ShowDetailsScreen`'s UI tests now test for `Rating`, `ActorCard` and `SeasonCard` components. During this implementation, it was noticed that our `Providers` component does not have UI tests. Created #1166 

## Screenshots

### Seasons Screen

![image](https://github.com/user-attachments/assets/0f9c94b6-7e96-49cf-8d2a-837eda14273f)

### `sm` breakpoint

![image](https://github.com/user-attachments/assets/db567b24-ff43-4f0b-8f38-0a67b346c2bb)

### TV Details Screen

![image](https://github.com/user-attachments/assets/3c80833c-6af4-499c-9c47-30e20a5fe603)


## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created
