### PR TITLE
SeasonDetailsScreen & EpisodeCard

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,21 +26,14 @@
         }
     },
     "rules": {
-        "indent": [
-            "error",
-            4,
-            {
-                "SwitchCase": 1
-            }
-        ],
         "linebreak-style": [
             "error",
             "unix"
         ],
-        "quotes": [
-            "error",
-            "single"
-        ],
+        // "quotes": [
+        //     "error",
+        //     "single"
+        // ],
         "semi": [
             "error",
             "always"

--- a/src/__tests__/components/ActorCard.test.tsx
+++ b/src/__tests__/components/ActorCard.test.tsx
@@ -1,12 +1,10 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import ActorCard from '../../components/ActorCard';
-import { ACTOR } from '../constants';
+import { ACTOR, TMDB_BASE_PATH } from '../constants';
 import { MemoryRouter, Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 import { vi } from 'vitest';
-
-const TMDB_BASE_PATH = 'https://image.tmdb.org/t/p/w500';
 
 describe('ActorCard', () => {
     it('properly renders with all actor info and image', () => {

--- a/src/__tests__/components/EpisodeCard.test.tsx
+++ b/src/__tests__/components/EpisodeCard.test.tsx
@@ -1,0 +1,278 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, act, within } from '@testing-library/react';
+import { EpisodeCard } from '../../components/';
+import { EPISODE, EPISODE_DETAILS, TMDB_BASE_PATH } from '../constants';
+import { MemoryRouter } from 'react-router';
+import { formatReleaseDate, DateSize, getTvEpisodeDetails } from '../../helpers';
+import { describe, it, vi } from 'vitest';
+
+vi.mock('../../helpers', async () => {
+    const actual = await vi.importActual('../../helpers');
+
+    return {
+        ...(actual as object),
+        getTvEpisodeDetails: vi.fn(),
+    };
+});
+
+describe('Episode Card', () => {
+    it('Properly renders default episode data on mobile viewports', () => {
+        act(() => {
+            window.innerWidth = 640;
+            window.dispatchEvent(new Event('resize'));
+        });
+        render(
+            <MemoryRouter>
+                <EpisodeCard details={EPISODE} />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByTestId('episode-card-component')).toBeInTheDocument();
+        expect(screen.getByAltText(`${EPISODE.name} poster`)).toBeInTheDocument();
+        expect(screen.getByText(`${EPISODE.episode_number}.`)).toBeInTheDocument();
+        expect(screen.getByText(EPISODE.name)).toBeInTheDocument();
+    });
+    it('properly expands when pressed on mobile viewports and renders additional episode data', async () => {
+        vi.mocked(getTvEpisodeDetails).mockResolvedValue(EPISODE_DETAILS);
+
+        await act(async () => {
+            window.innerWidth = 640;
+            window.dispatchEvent(new Event('resize'));
+        });
+
+        render(
+            <MemoryRouter>
+                <EpisodeCard details={EPISODE} />
+            </MemoryRouter>
+        );
+        expect(screen.getByTestId('episode-card-component')).toBeInTheDocument();
+        await act(async () => {
+            fireEvent.click(screen.getByText('Expand'));
+        });
+
+        expect(screen.getByText(EPISODE.vote_average)).toBeInTheDocument();
+        expect(
+            screen.getByText(formatReleaseDate(EPISODE.air_date, DateSize.MEDIUM))
+        ).toBeInTheDocument();
+        expect(screen.getByText(`${EPISODE.runtime}m`));
+        expect(screen.getByText(EPISODE.overview)).toBeInTheDocument();
+
+        expect(screen.getByText('Cast')).toBeInTheDocument();
+        EPISODE_DETAILS.credits.cast.map((item) => {
+            expect(screen.getByAltText(`${item.name} poster`).parentElement).toHaveAttribute(
+                'href',
+                `/details/actor/${item.id}`
+            );
+            const actorContainer = within(
+                screen.getByAltText(`${item.name} poster`).parentElement!
+            );
+            expect(actorContainer.getByText(item.character)).toBeInTheDocument();
+            expect(actorContainer.getByText(item.name)).toBeInTheDocument();
+            expect(actorContainer.getByRole('img')).toHaveAttribute(
+                'src',
+                TMDB_BASE_PATH + item.profile_path
+            );
+        });
+
+        expect(screen.getByText('Guest Stars')).toBeInTheDocument();
+        EPISODE.guest_stars.map((item) => {
+            expect(screen.getByAltText(`${item.name} poster`).parentElement).toHaveAttribute(
+                'href',
+                `/details/actor/${item.id}`
+            );
+            const actorContainer = within(
+                screen.getByAltText(`${item.name} poster`).parentElement!
+            );
+            expect(actorContainer.getByText(item.character)).toBeInTheDocument();
+            expect(actorContainer.getByText(item.name)).toBeInTheDocument();
+            expect(actorContainer.getByRole('img')).toHaveAttribute(
+                'src',
+                TMDB_BASE_PATH + item.profile_path
+            );
+        });
+
+        expect(screen.getByText('Crew')).toBeInTheDocument();
+        EPISODE.crew.map((item) => {
+            expect(screen.getByAltText(`${item.name} poster`).parentElement).toHaveAttribute(
+                'href',
+                `/details/actor/${item.id}`
+            );
+            const actorContainer = within(
+                screen.getByAltText(`${item.name} poster`).parentElement!
+            );
+            expect(actorContainer.getByText(item.job)).toBeInTheDocument();
+            expect(actorContainer.getByText(item.name)).toBeInTheDocument();
+            expect(actorContainer.getByRole('img')).toHaveAttribute(
+                'src',
+                TMDB_BASE_PATH + item.profile_path
+            );
+        });
+    });
+    it('properly renders fallback text and/or placeholder image on mobile viewports', async () => {
+        vi.mocked(getTvEpisodeDetails).mockResolvedValue({
+            ...EPISODE_DETAILS,
+            credits: { cast: [] },
+        });
+
+        await act(async () => {
+            window.innerWidth = 640;
+            window.dispatchEvent(new Event('resize'));
+        });
+
+        render(
+            <MemoryRouter>
+                <EpisodeCard
+                    details={{
+                        ...EPISODE,
+                        still_path: '',
+                        overview: '',
+                        guest_stars: [],
+                        crew: [],
+                    }}
+                />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByTestId('episode-card-component')).toBeInTheDocument();
+        expect(screen.getByAltText(`${EPISODE.name} poster`)).toHaveAttribute(
+            'src',
+            '/poster-placeholder.jpeg'
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Expand'));
+        });
+
+        expect(screen.getByText("Sorry, we don't have additional information about this episode!"));
+    });
+    it('properly renders default episode data on tablet+ viewports', async () => {
+        act(() => {
+            window.innerWidth = 1200;
+            window.dispatchEvent(new Event('resize'));
+        });
+        render(
+            <MemoryRouter>
+                <EpisodeCard details={EPISODE} />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByTestId('episode-card-component')).toBeInTheDocument();
+        expect(screen.getByAltText(`${EPISODE.name} poster`)).toBeInTheDocument();
+        expect(screen.getByText(`${EPISODE.episode_number}.`)).toBeInTheDocument();
+        expect(screen.getByText(EPISODE.name)).toBeInTheDocument();
+        expect(screen.getByText(EPISODE.vote_average)).toBeInTheDocument();
+        expect(
+            screen.getByText(formatReleaseDate(EPISODE.air_date, DateSize.MEDIUM))
+        ).toBeInTheDocument();
+        expect(screen.getByText(`${EPISODE.runtime}m`));
+        expect(screen.getByText(EPISODE.overview)).toBeInTheDocument();
+    });
+    it('properly expands menu when pressed on tablet+ viewports and renders additional episode data', async () => {
+        vi.mocked(getTvEpisodeDetails).mockResolvedValue(EPISODE_DETAILS);
+
+        await act(async () => {
+            window.innerWidth = 1200;
+            window.dispatchEvent(new Event('resize'));
+        });
+
+        render(
+            <MemoryRouter>
+                <EpisodeCard details={EPISODE} />
+            </MemoryRouter>
+        );
+        expect(screen.getByTestId('episode-card-component')).toBeInTheDocument();
+        await act(async () => {
+            fireEvent.click(screen.getByText('Expand'));
+        });
+
+        expect(screen.getByText('Cast')).toBeInTheDocument();
+        EPISODE_DETAILS.credits.cast.map((item) => {
+            expect(screen.getByAltText(`${item.name} poster`).parentElement).toHaveAttribute(
+                'href',
+                `/details/actor/${item.id}`
+            );
+            const actorContainer = within(
+                screen.getByAltText(`${item.name} poster`).parentElement!
+            );
+            expect(actorContainer.getByText(item.character)).toBeInTheDocument();
+            expect(actorContainer.getByText(item.name)).toBeInTheDocument();
+            expect(actorContainer.getByRole('img')).toHaveAttribute(
+                'src',
+                TMDB_BASE_PATH + item.profile_path
+            );
+        });
+
+        expect(screen.getByText('Guest Stars')).toBeInTheDocument();
+        EPISODE.guest_stars.map((item) => {
+            expect(screen.getByAltText(`${item.name} poster`).parentElement).toHaveAttribute(
+                'href',
+                `/details/actor/${item.id}`
+            );
+            const actorContainer = within(
+                screen.getByAltText(`${item.name} poster`).parentElement!
+            );
+            expect(actorContainer.getByText(item.character)).toBeInTheDocument();
+            expect(actorContainer.getByText(item.name)).toBeInTheDocument();
+            expect(actorContainer.getByRole('img')).toHaveAttribute(
+                'src',
+                TMDB_BASE_PATH + item.profile_path
+            );
+        });
+
+        expect(screen.getByText('Crew')).toBeInTheDocument();
+        EPISODE.crew.map((item) => {
+            expect(screen.getByAltText(`${item.name} poster`).parentElement).toHaveAttribute(
+                'href',
+                `/details/actor/${item.id}`
+            );
+            const actorContainer = within(
+                screen.getByAltText(`${item.name} poster`).parentElement!
+            );
+            expect(actorContainer.getByText(item.job)).toBeInTheDocument();
+            expect(actorContainer.getByText(item.name)).toBeInTheDocument();
+            expect(actorContainer.getByRole('img')).toHaveAttribute(
+                'src',
+                TMDB_BASE_PATH + item.profile_path
+            );
+        });
+
+        expect(screen.getByText('Episode Images')).toBeInTheDocument();
+        const menu = within(screen.getByTestId('episode-card-component-menu'));
+        EPISODE_DETAILS.images?.stills.map((item, i) => {
+            expect(menu.getByAltText(`episode image ${i}`)).toHaveAttribute(
+                'src',
+                TMDB_BASE_PATH + item.file_path
+            );
+        });
+    });
+    it('properly renders fallback text and/or placeholder image on tablet+ viewports', async () => {
+        vi.mocked(getTvEpisodeDetails).mockResolvedValue({
+            ...EPISODE_DETAILS,
+            credits: { cast: [] },
+            images: { stills: [] },
+        });
+
+        await act(async () => {
+            window.innerWidth = 1200;
+            window.dispatchEvent(new Event('resize'));
+        });
+
+        render(
+            <MemoryRouter>
+                <EpisodeCard details={{ ...EPISODE, still_path: '', guest_stars: [], crew: [] }} />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByTestId('episode-card-component')).toBeInTheDocument();
+        expect(screen.getByAltText(`${EPISODE.name} poster`)).toHaveAttribute(
+            'src',
+            '/poster-placeholder.jpeg'
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Expand'));
+        });
+
+        expect(screen.getByText("Sorry, we don't have additional information about this episode!"));
+    });
+});

--- a/src/__tests__/components/SeasonCard.test.tsx
+++ b/src/__tests__/components/SeasonCard.test.tsx
@@ -1,14 +1,12 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, act } from '@testing-library/react';
 import { SeasonCard } from '../../components/';
-import { SEASON, TV_DETAIL } from '../constants';
+import { SEASON, TV_DETAIL, TMDB_BASE_PATH } from '../constants';
 import { MemoryRouter, Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 import { pluralizeString } from '../../helpers';
 
-const TMDB_BASE_PATH = 'https://image.tmdb.org/t/p/w500';
-
-describe('SeasonCard', () => {
+describe('Season Card', () => {
     it('properly renders with all season info and image', () => {
         render(
             <MemoryRouter>

--- a/src/__tests__/components/ShowCard.test.tsx
+++ b/src/__tests__/components/ShowCard.test.tsx
@@ -3,12 +3,11 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { describe, vi } from 'vitest';
 import { ShowCard } from '../../components';
-import { MOVIE_DETAIL, PROFILE } from '../constants';
+import { MOVIE_DETAIL, PROFILE, TMDB_BASE_PATH } from '../constants';
 import useTheme from '@mui/material/styles/useTheme';
 import { lightTheme } from '../../theme';
 import { DateSize, formatReleaseDate } from '../../helpers';
 
-const TMDB_BASE_PATH = 'https://image.tmdb.org/t/p/w500';
 const mockedUseNavigate = vi.fn();
 const mockSetProfile = vi.fn();
 

--- a/src/__tests__/components/ShowListCard.test.tsx
+++ b/src/__tests__/components/ShowListCard.test.tsx
@@ -3,10 +3,9 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { describe, vi } from 'vitest';
 import { ShowListCard } from '../../components';
-import { MOVIE_DETAIL, PROFILE } from '../constants';
+import { MOVIE_DETAIL, PROFILE, TMDB_BASE_PATH } from '../constants';
 import { DateSize, formatReleaseDate } from '../../helpers';
 
-const TMDB_BASE_PATH = 'https://image.tmdb.org/t/p/w500';
 const mockedUseNavigate = vi.fn();
 const mockSetProfile = vi.fn();
 

--- a/src/__tests__/components/ShowPoster.test.tsx
+++ b/src/__tests__/components/ShowPoster.test.tsx
@@ -2,14 +2,12 @@ import '@testing-library/jest-dom';
 import { describe, it, vi } from 'vitest';
 import { screen, render, fireEvent, waitFor } from '@testing-library/react';
 import ShowPoster from '../../components/ShowPoster';
-import { MOVIE_DETAIL, PROFILE, PROFILE_ACTIONS, TV_DETAIL } from '../constants';
+import { MOVIE_DETAIL, PROFILE, PROFILE_ACTIONS, TV_DETAIL, TMDB_BASE_PATH } from '../constants';
 import { MemoryRouter, Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 import { ThemeProvider } from '@emotion/react';
 import { lightTheme } from '../../theme';
 import useTheme from '@mui/material/styles/useTheme';
-
-const TMDB_BASE_PATH = 'https://image.tmdb.org/t/p/w500';
 
 vi.mock('@mui/material/styles/useTheme', async () => ({
     __esModule: true,

--- a/src/__tests__/constants.ts
+++ b/src/__tests__/constants.ts
@@ -1,4 +1,14 @@
-import { Profile, ProfileActions, Session, ShowData, Season } from '../types';
+import {
+    Profile,
+    ProfileActions,
+    Session,
+    ShowData,
+    SeasonDetails,
+    Episode,
+    EpisodeDetails,
+} from '../types';
+
+export const TMDB_BASE_PATH = 'https://image.tmdb.org/t/p/w500';
 
 /* eslint-disable prettier/prettier */
 export const TRENDING_DATA: ShowData[] = [
@@ -259,9 +269,9 @@ export const ACTOR = {
     order: 0
 };
 
-export const SEASON: Season = {
+export const SEASON: SeasonDetails = {
     air_date: '2011-04-17',
-    episode_count: 10,
+    episode_count: 1,
     id: 3624,
     name: 'Season 1',
     overview:
@@ -269,4 +279,200 @@ export const SEASON: Season = {
     poster_path: '/wgfKiqzuMrFIkU1M68DDDY8kGC1.jpg',
     season_number: 1,
     vote_average: 8.3,
+    _id: '5256c89f19c2956ff6046d47',
+    episodes: [
+        {
+            air_date: '2011-04-17',
+            episode_number: 1,
+            id: 63056,
+            name: 'Winter Is Coming',
+            overview: 'Jon Arryn, the Hand of the King, is dead. King Robert Baratheon plans to ask his oldest friend, Eddard Stark, to take Jon\'s place. Across the sea, Viserys Targaryen plans to wed his sister to a nomadic warlord in exchange for an army.',
+            production_code: '101',
+            runtime: 62,
+            season_number: 1,
+            show_id: 1399,
+            still_path: '/9hGF3WUkBf7cSjMg0cdMDHJkByd.jpg',
+            vote_average: 8.033,
+            vote_count: 361,
+            crew: [],
+            guest_stars: [],
+        }
+    ]
+};
+
+export const EPISODE: Episode = {
+    air_date: '2011-04-17',
+    episode_number: 1,
+    id: 63056,
+    name: 'Winter Is Coming',
+    overview: 'Jon Arryn, the Hand of the King, is dead. King Robert Baratheon plans to ask his oldest friend, Eddard Stark, to take Jon\'s place. Across the sea, Viserys Targaryen plans to wed his sister to a nomadic warlord in exchange for an army.',
+    production_code: '101',
+    runtime: 62,
+    season_number: 1,
+    show_id: 1399,
+    still_path: '/9hGF3WUkBf7cSjMg0cdMDHJkByd.jpg',
+    vote_average: 8.033,
+    vote_count: 361,
+    crew: [
+        {
+            job: 'Writer',
+            department: 'Writing',
+            credit_id: '5256c8a019c2956ff6046e2b',
+            adult: false,
+            gender: 2,
+            id: 9813,
+            known_for_department: 'Writing',
+            name: 'David Benioff',
+            original_name: 'David Benioff',
+            popularity: 0.066,
+            profile_path: '/bOlW8pymCeQLfwPIvc2D1MRcUoF.jpg'
+        },
+        {
+            department: 'Directing',
+            job: 'Director',
+            credit_id: '5256c8a219c2956ff6046e77',
+            adult: false,
+            gender: 2,
+            id: 44797,
+            known_for_department: 'Directing',
+            name: 'Tim Van Patten',
+            original_name: 'Tim Van Patten',
+            popularity: 0.058,
+            profile_path: '/vwcARZBg4PEzOwnPsXdjRWeUVrZ.jpg'
+        },
+        {
+            job: 'Writer',
+            department: 'Writing',
+            credit_id: '5256c8a219c2956ff6046e4b',
+            adult: false,
+            gender: 2,
+            id: 228068,
+            known_for_department: 'Writing',
+            name: 'D. B. Weiss',
+            original_name: 'D. B. Weiss',
+            popularity: 0.043,
+            profile_path: '/2RMejaT793U9KRk2IEbFfteQntE.jpg'
+        }
+    ],
+    guest_stars: [
+        {
+            character: 'Benjen Stark',
+            credit_id: '5256c8b919c2956ff604836a',
+            order: 61,
+            adult: false,
+            gender: 2,
+            id: 119783,
+            known_for_department: 'Acting',
+            name: 'Joseph Mawle',
+            original_name: 'Joseph Mawle',
+            popularity: 0.101,
+            profile_path: '/1Ocb9v3h54beGVoJMm4w50UQhLf.jpg'
+        },
+        {
+            character: 'Rickon Stark',
+            credit_id: '566a83bcc3a3683f56003604',
+            order: 80,
+            adult: false,
+            gender: 2,
+            id: 1050248,
+            known_for_department: 'Acting',
+            name: 'Art Parkinson',
+            original_name: 'Art Parkinson',
+            popularity: 0.041,
+            profile_path: '/ejAKOJME1DsvHECLWdQ7dEtXyyc.jpg'
+        },
+        {
+            character: 'Hodor',
+            credit_id: '5256c8be19c2956ff6048446',
+            order: 81,
+            adult: false,
+            gender: 2,
+            id: 1223792,
+            known_for_department: 'Acting',
+            name: 'Kristian Nairn',
+            original_name: 'Kristian Nairn',
+            popularity: 0.028,
+            profile_path: '/dlbq6cCW0xdpFY15q6flP6lDXWV.jpg'
+        }
+    ]
+};
+
+export const EPISODE_DETAILS: EpisodeDetails = {
+    credits: {
+        cast: [
+            {
+                adult: false,
+                gender: 2,
+                id: 22970,
+                known_for_department: 'Acting',
+                name: 'Peter Dinklage',
+                original_name: 'Peter Dinklage',
+                popularity: 0.327,
+                profile_path: '/9CAd7wr8QZyIN0E7nm8v1B6WkGn.jpg',
+                character: 'Tyrion \'The Halfman\' Lannister',
+                credit_id: '5256c8b219c2956ff6047cd8',
+                order: 0
+            },
+            {
+                adult: false,
+                gender: 2,
+                id: 239019,
+                known_for_department: 'Acting',
+                name: 'Kit Harington',
+                original_name: 'Kit Harington',
+                popularity: 0.188,
+                profile_path: '/4MqUjb1SYrzHmFSyGiXnlZWLvBs.jpg',
+                character: 'Jon Snow',
+                credit_id: '5256c8af19c2956ff6047af6',
+                order: 1
+            },
+            {
+                adult: false,
+                gender: 2,
+                id: 48,
+                known_for_department: 'Acting',
+                name: 'Sean Bean',
+                original_name: 'Sean Bean',
+                popularity: 0.298,
+                profile_path: '/kTjiABk3TJ3yI0Cto5RsvyT6V3o.jpg',
+                character: 'Lord Eddard \'Ned\' Stark',
+                credit_id: '58c7134792514179d20011a9',
+                order: 2
+            }
+        ]
+    },
+    images: {
+        stills: [
+            {
+                aspect_ratio: 1.778,
+                height: 1080,
+                iso_639_1: 'en',
+                file_path: '/9hGF3WUkBf7cSjMg0cdMDHJkByd.jpg',
+                vote_average: 6.312,
+                vote_count: 8,
+                width: 1920
+            },
+            {
+                aspect_ratio: 1.778,
+                height: 1080,
+                iso_639_1: 'en',
+                file_path: '/wrGWeW4WKxnaeA8sxJb2T9O6ryo.jpg',
+                vote_average: 5.06,
+                vote_count: 11,
+                width: 1920
+            },
+            {
+                aspect_ratio: 1.777,
+                height: 995,
+                iso_639_1: 'en',
+                file_path: '/c05nayHjwQR2uPwkQwNy4UVVQlt.jpg',
+                vote_average: 3.334,
+                vote_count: 1,
+                width: 1768
+            }
+        ]
+    },
+    videos: {
+        results: []
+    }
 };

--- a/src/__tests__/screens/SeasonDetailsScreen.test.tsx
+++ b/src/__tests__/screens/SeasonDetailsScreen.test.tsx
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom';
+import { describe, it, vi } from 'vitest';
+import { fireEvent, render, screen, act } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router';
+import { routes } from '../../routes';
+import { getTvSeasonDetails } from '../../helpers';
+import { SEASON, TV_DETAIL, TMDB_BASE_PATH } from '../constants';
+
+vi.mock('../../helpers', async () => {
+    const actual = await vi.importActual('../../helpers');
+
+    return {
+        ...(actual as object),
+        getTvSeasonDetails: vi.fn(),
+    };
+});
+
+const seasonRouter = createMemoryRouter(routes, {
+    initialEntries: [`/details/tv/${TV_DETAIL.id}/seasons/${SEASON.season_number}`],
+});
+
+describe('Season Details Screen', () => {
+    it('properly renders season data and associated EpisodeCards', async () => {
+        vi.mocked(getTvSeasonDetails).mockResolvedValue(SEASON);
+
+        render(<RouterProvider router={seasonRouter} />);
+
+        await screen.findByTestId('season-details-screen');
+        expect(screen.getByText(SEASON.name)).toBeInTheDocument();
+        expect(screen.getByText('(' + SEASON.air_date?.slice(0, 4) + ')'));
+        expect(screen.getByAltText(`${SEASON.name} poster`)).toHaveAttribute(
+            'src',
+            TMDB_BASE_PATH + SEASON.poster_path
+        );
+        expect(screen.getAllByTestId('episode-card-component').length).toBe(SEASON.episode_count);
+    });
+    it('properly renders placeholder image if no season poster path is provided', async () => {
+        vi.mocked(getTvSeasonDetails).mockResolvedValue({ ...SEASON, poster_path: null });
+        render(<RouterProvider router={seasonRouter} />);
+
+        await screen.findByTestId('season-details-screen');
+        expect(screen.getByAltText(`${SEASON.name} poster`)).toHaveAttribute(
+            'src',
+            '/poster-placeholder.jpeg'
+        );
+    });
+    it('properly provides link that navigates back to seasons screen', async () => {
+        vi.mocked(getTvSeasonDetails).mockResolvedValue(SEASON);
+
+        render(<RouterProvider router={seasonRouter} />);
+
+        await screen.findByTestId('season-details-screen');
+        await act(async () => {
+            fireEvent.click(await screen.findByRole('link', { name: 'Back to Seasons' }));
+        });
+        expect(seasonRouter.state.location.pathname).toBe(`/details/tv/${TV_DETAIL.id}/seasons`);
+    });
+});

--- a/src/__tests__/screens/SeasonsScreen.test.tsx
+++ b/src/__tests__/screens/SeasonsScreen.test.tsx
@@ -4,9 +4,7 @@ import { fireEvent, render, screen, act } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router';
 import { routes } from '../../routes';
 import { getTvDetails } from '../../helpers';
-import { TV_DETAIL } from '../constants';
-
-const TMDB_BASE_PATH = 'https://image.tmdb.org/t/p/w500';
+import { TV_DETAIL, TMDB_BASE_PATH } from '../constants';
 
 vi.mock('../../helpers', async () => {
     const actual = await vi.importActual('../../helpers');
@@ -48,7 +46,7 @@ describe('Seasons Screen', () => {
             '/poster-placeholder.jpeg'
         );
     });
-    it('page header properly provides link that navigates back to TV details', async () => {
+    it('properly provides link that navigates back to TV details', async () => {
         vi.mocked(getTvDetails).mockResolvedValue(TV_DETAIL);
 
         render(<RouterProvider router={tvRouter} />);

--- a/src/__tests__/screens/ShowDetailsScreen.test.tsx
+++ b/src/__tests__/screens/ShowDetailsScreen.test.tsx
@@ -88,8 +88,8 @@ describe('Show Details Screen', () => {
         await act(async () => {
             fireEvent.click(await screen.findByRole('link', { name: 'View All Seasons' }));
             expect(tvRouter.state.location.pathname).toBe(`/details/tv/${TV_DETAIL.id}/seasons`);
+            await tvRouter.navigate(`/details/tv/${TV_DETAIL.id}}`);
         });
-        tvRouter.state.location.pathname = `/details/tv/${TV_DETAIL.id}}`;
     });
     it('shows recommendation carousel when recommendation data is returned', async () => {
         vi.mocked(getMovieDetails).mockResolvedValue(MOVIE_DETAIL);

--- a/src/components/EpisodeCard.tsx
+++ b/src/components/EpisodeCard.tsx
@@ -1,44 +1,63 @@
 import { useState, useEffect } from 'react';
-import { Actor, Episode, EpisodeDetails } from '../types';
+import { Actor, Crew, Episode, EpisodeDetails } from '../types';
 import { CardMedia, Typography as Typ } from '@mui/material';
 import Divider from '@mui/material/Divider';
-import { ExpandLess, ExpandMore } from '@mui/icons-material/';
+import ExpandLess from '@mui/icons-material/ExpandLess';
+import ExpandMore from '@mui/icons-material/ExpandMore';
 import { formatReleaseDate, DateSize } from '../helpers';
 import { getTvEpisodeDetails } from '../helpers';
 import { Link } from 'react-router';
+import { useWindowSize } from '../hooks';
 
 interface EpisodeCardProps {
     details: Episode;
 }
 
 /**
- * Component to render a TV Show Episode and its details
+ * Renders episode details for a TV Show
+ * @param details
+ * @returns {JSX.Element}
  */
 const EpisodeCard: React.FC<EpisodeCardProps> = ({ details }): JSX.Element => {
-    const [expand, setExpand] = useState<boolean>(false);
     const [episodeDetails, setEpisodeDetails] = useState<EpisodeDetails | null>(null);
-    console.log(details);
+    const [expand, setExpand] = useState<boolean>(false);
+    const windowSize = useWindowSize();
 
     useEffect(() => {
         const handler = async () => {
-            const episodeDetails = await getTvEpisodeDetails(
+            const epDetails = await getTvEpisodeDetails(
                 details.show_id,
                 details.season_number,
                 details.episode_number
             );
-            setEpisodeDetails(episodeDetails);
-            // console.log(episodeDetails);
+            setEpisodeDetails(epDetails);
         };
         if (expand && !episodeDetails) handler();
     }, [expand]);
 
-    const renderActors = (actors: (Actor & { job?: string })[], title: 'Cast' | 'Guest Stars' | 'Crew', isCrew?: boolean): JSX.Element => {
+    /**
+     * Util function for rendering Cast, Guest Stars, and Crew
+     * @param actors
+     * @param title
+     * @param isCrew
+     * @returns {JSX.Element}
+     */
+    const renderActors = (
+        actors: Actor[] | Crew[],
+        title: 'Cast' | 'Guest Stars' | 'Crew'
+    ): JSX.Element => {
         return (
             <div className='my-2'>
-                <Typ fontWeight={'bold'} variant='body2' textAlign={'left'}>{title}</Typ>
+                <Typ fontWeight={'bold'} variant='body2' textAlign={'left'}>
+                    {title}
+                </Typ>
                 <div className='flex overflow-x-scroll'>
                     {actors.map((item, i) => (
-                        <Link to={`/details/actor/${item.id}`} key={i} className='flex items-center my-2 space-x-1 mr-4 md:min-w-[180px]'>
+                        <Link
+                            to={`/details/actor/${item.id}`}
+                            key={i}
+                            className='flex items-center my-2 space-x-1 mr-4 md:min-w-[180px]'
+                        >
                             <CardMedia
                                 component='img'
                                 className='rounded-lg'
@@ -47,8 +66,7 @@ const EpisodeCard: React.FC<EpisodeCardProps> = ({ details }): JSX.Element => {
                                     width: 66,
                                     minWidth: 66,
                                     height: 66,
-                                    '&:hover': { cursor: 'pointer' },
-
+                                    '&:hover': { cursor: 'pointer', opacity: 0.8 },
                                 }}
                                 image={
                                     item.profile_path
@@ -58,30 +76,46 @@ const EpisodeCard: React.FC<EpisodeCardProps> = ({ details }): JSX.Element => {
                                 alt={item.name + ' poster'}
                             />
                             <div className='flex-1 min-w-0'>
-                                <Typ className='text-left hover:text-blue-500 truncate' fontWeight={'bold'} variant='body2'>{item.name}</Typ>
-                                <Typ className='text-left truncate' variant='body2'>{!isCrew ? item.character : item.job}</Typ>
+                                <Typ
+                                    textAlign={'left'}
+                                    fontWeight={'bold'}
+                                    variant='body2'
+                                    className='hover:text-blue-500 truncate'
+                                >
+                                    {item.name}
+                                </Typ>
+                                <Typ textAlign={'left'} variant='body2' className='truncate'>
+                                    {'character' in item ? item.character : item.job}
+                                </Typ>
                             </div>
                         </Link>
                     ))}
                 </div>
             </div>
-        )
-    }
+        );
+    };
 
-    const renderMetaData = (details: Episode) => {
+    /**
+     * Renders a Episode's metadata
+     * @param details
+     * @returns {JSX.Element}
+     */
+    const renderMetaData = (details: Episode): JSX.Element => {
         return (
             <>
                 <Typ variant='subtitle1'>{details.vote_average}</Typ>
-                <Typ variant='subtitle1'>
-                    {formatReleaseDate(details.air_date, DateSize.MEDIUM)}
-                </Typ>
-                <Typ variant='subtitle1'>{details.runtime}m</Typ>
+                {details.air_date && (
+                    <Typ variant='subtitle1'>
+                        {formatReleaseDate(details.air_date, DateSize.MEDIUM)}
+                    </Typ>
+                )}
+                {details.runtime && <Typ variant='subtitle1'>{details.runtime}m</Typ>}
             </>
-        )
-    }
+        );
+    };
 
     return (
-        <div className='my-3 bg-foreground rounded-b-md w-full rounded-sm max-w-[275px] md:max-w-none'>
+        <div className='my-3 bg-foreground rounded-b-md rounded-sm max-w-[275px] md:max-w-none w-full'>
             <div data-testid='episode-card-component' className='flex flex-col md:flex-row '>
                 <CardMedia
                     component='img'
@@ -89,8 +123,8 @@ const EpisodeCard: React.FC<EpisodeCardProps> = ({ details }): JSX.Element => {
                     sx={{
                         boxShadow: 5,
                         width: 275,
-                        maxHeight: 270,
-                        '&:hover': { cursor: 'pointer' },
+                        minWidth: 275,
+                        height: 150,
                     }}
                     image={
                         details.still_path
@@ -100,134 +134,151 @@ const EpisodeCard: React.FC<EpisodeCardProps> = ({ details }): JSX.Element => {
                     alt={details.name + ' poster'}
                 />
                 <div className='px-3 flex flex-col truncate'>
-                    <div className='py-2 w-full flex justify-between items-center md:justify-start truncate md:space-x-2'>
+                    <div className='py-2 flex md:space-x-2'>
                         <Typ>{details.episode_number}.</Typ>
-                        <Typ fontWeight={'bold'} className='grow md:grow-0 truncate'>
+                        <Typ
+                            fontWeight={'bold'}
+                            textAlign={'center'}
+                            className='grow md:grow-0 truncate'
+                        >
                             {details.name}
                         </Typ>
                     </div>
-                    <div className='hidden md:flex space-x-3'>
-                        {renderMetaData(details)}
-                    </div>
-                    <div className='py-2 hidden md:block'>
-                        <Typ
-                            variant='body2'
-                            className='text-wrap text-left hidden md:block'
-                            sx={{
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                display: '-webkit-box',
-                                WebkitLineClamp: '3',
-                                WebkitBoxOrient: 'vertical',
-                            }}
-                        >
-                            {details.overview}
-                        </Typ>
-                    </div>
+                    {windowSize.width && windowSize.width >= 768 && (
+                        <div>
+                            <div className='flex space-x-3'>{renderMetaData(details)}</div>
+                            <Typ
+                                variant='body2'
+                                textAlign={'left'}
+                                className='pt-2 text-wrap'
+                                sx={{
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    display: '-webkit-box',
+                                    WebkitLineClamp: '3',
+                                    WebkitBoxOrient: 'vertical',
+                                }}
+                            >
+                                {details.overview}
+                            </Typ>
+                        </div>
+                    )}
                 </div>
-                {/* Expand mobile */}
+                {/* Mobile expand menu */}
+                <Divider />
+                {windowSize.width && windowSize.width < 768 && (
+                    <div
+                        data-testid='episode-card-component-menu'
+                        style={{
+                            maxHeight: expand ? '600px' : '0px',
+                            overflow: 'hidden',
+                            transition: 'max-height .5s ease-in-out',
+                        }}
+                    >
+                        <div className='p-4'>
+                            <div className='flex flex-row justify-center space-x-3'>
+                                {renderMetaData(details)}
+                            </div>
+                            <Typ
+                                variant='body2'
+                                textAlign={'left'}
+                                className='pt-4'
+                                sx={{
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    display: '-webkit-box',
+                                    WebkitLineClamp: '15',
+                                    WebkitBoxOrient: 'vertical',
+                                }}
+                            >
+                                {details.overview}
+                            </Typ>
+                            {episodeDetails?.credits.cast &&
+                                episodeDetails?.credits.cast.length > 0 &&
+                                renderActors(episodeDetails.credits.cast, 'Cast')}
+                            {details?.guest_stars.length > 0 &&
+                                renderActors(details.guest_stars, 'Guest Stars')}
+                            {details?.crew.length > 0 && renderActors(details.crew, 'Crew')}
+                        </div>
+
+                        {episodeDetails?.credits.cast.length == 0 &&
+                            details?.guest_stars.length == 0 &&
+                            details?.crew.length == 0 &&
+                            !details.overview && (
+                                <Typ variant='body2' textAlign={'center'} className='pt-2'>
+                                    {
+                                        "Sorry, we don't have additional information about this episode!"
+                                    }
+                                </Typ>
+                            )}
+                    </div>
+                )}
+            </div>
+            {/* Tablet+ expand menu */}
+            {windowSize.width && windowSize.width > 768 && (
                 <div
+                    data-testid='episode-card-component-menu'
                     style={{
-                        maxHeight: expand ? '600px' : '0px',
+                        maxHeight: expand ? '850px' : '0px',
                         overflow: 'hidden',
                         transition: 'max-height .5s ease-in-out',
                     }}
                 >
                     <Divider />
-                    <div className='md:hidden p-4'>
-                        <div className='flex flex-row justify-start space-x-3'>
-                            {renderMetaData(details)}
-                        </div>
-                        <Typ
-                            className='text-left pt-4'
-                            sx={{
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                display: '-webkit-box',
-                                WebkitLineClamp: '15',
-                                WebkitBoxOrient: 'vertical',
-                            }}
-                            variant='body2'
-                        >
-                            {details.overview}
-                        </Typ>
-                        <div className='text-left pt-4'>
-                            {/* possible undefined values WIP */}
-                            <Typ variant='body2'>
-                                Directed by:{' '}
-                                {details.crew.find((item) => item.job == 'Director')?.name}
-                            </Typ>
-                            <Typ variant='body2'>
-                                Written by:{' '}
-                                {
-                                    details.crew.find(
-                                        (item) => item.job == 'Writer' || item.job == 'Story'
-                                    )?.name
-                                }
-                            </Typ>
-                        </div>
+                    <div className='flex flex-col px-4'>
                         {episodeDetails?.credits.cast &&
-                            renderActors(episodeDetails.credits.cast, 'Cast')
-                        }
-                        {details?.guest_stars &&
-                            renderActors(details.guest_stars, 'Guest Stars')
-                        }
+                            episodeDetails?.credits.cast.length > 0 &&
+                            renderActors(episodeDetails.credits.cast, 'Cast')}
+                        {details?.guest_stars.length > 0 &&
+                            renderActors(details.guest_stars, 'Guest Stars')}
+                        {details?.crew.length > 0 && renderActors(details.crew, 'Crew')}
+                        {episodeDetails?.images.stills &&
+                            episodeDetails.images.stills.length > 0 && (
+                                <div className='flex-col my-2'>
+                                    <Typ fontWeight={'bold'} variant='body2' textAlign={'left'}>
+                                        Episode Images
+                                    </Typ>
+                                    <div className='flex overflow-x-scroll'>
+                                        {episodeDetails?.images.stills.map((item, i) => (
+                                            <div key={i} className='mt-2 mr-2'>
+                                                <CardMedia
+                                                    component='img'
+                                                    className='rounded-sm'
+                                                    sx={{
+                                                        boxShadow: 5,
+                                                        minWidth: 275,
+                                                        height: 150,
+                                                    }}
+                                                    image={
+                                                        details.still_path
+                                                            ? `https://image.tmdb.org/t/p/w500${item.file_path}`
+                                                            : '/poster-placeholder.jpeg'
+                                                    }
+                                                    alt={'episode image ' + i}
+                                                />
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                            )}
+
+                        {episodeDetails?.credits.cast.length == 0 &&
+                            details?.guest_stars.length == 0 &&
+                            details?.crew.length == 0 &&
+                            episodeDetails.images.stills.length == 0 && (
+                                <Typ variant='body2' textAlign={'center'} className='pt-2'>
+                                    {
+                                        "Sorry, we don't have additional information about this episode!"
+                                    }
+                                </Typ>
+                            )}
                     </div>
                 </div>
-
-            </div>
-            {/* >:md expand menu */}
-            <div className='hidden md:block px-4'
-                style={{
-                    maxHeight: expand ? '850px' : '0px',
-                    overflow: 'hidden',
-                    transition: 'max-height .5s ease-in-out',
-                }}
-            >
-                <Divider />
-                <div className='flex flex-col'>
-                    {episodeDetails?.credits.cast &&
-                        renderActors(episodeDetails.credits.cast, 'Cast')
-                    }
-                    {details?.guest_stars &&
-                        renderActors(details.guest_stars, 'Guest Stars')
-                    }
-                    {details?.crew &&
-                        renderActors(details.crew, 'Crew', true)
-                    }
-                    {episodeDetails?.images &&
-                        <div className='text-left flex-col my-2'>
-                            <Typ fontWeight={'bold'} variant='body2' textAlign={'left'}>Episode Images</Typ>
-                            <div className='flex'>
-                                {episodeDetails?.images.stills.map((item, i) => (
-                                    <div key={i} className=''>
-                                        <CardMedia
-                                            component='img'
-                                            className='rounded-sm'
-                                            sx={{
-                                                boxShadow: 5,
-                                                width: 210,
-                                                maxHeight: 270,
-                                                '&:hover': { cursor: 'pointer' },
-                                            }}
-                                            image={
-                                                details.still_path
-                                                    ? `https://image.tmdb.org/t/p/w500${item.file_path}`
-                                                    : '/poster-placeholder.jpeg'
-                                            }
-                                            alt={details.name + ' poster'}
-                                        />
-                                    </div>
-                                ))}
-                            </div>
-                        </div>
-                    }
-                </div>
-            </div>
+            )}
             <Divider />
             <div
                 onClick={() => setExpand(!expand)}
-                className='py-1 px-2 cursor-pointer hover:opacity-70'
+                className='py-1 px-2 cursor-pointer hover:opacity-70 flex justify-center'
             >
                 <Typ variant='subtitle2'>Expand{expand ? <ExpandLess /> : <ExpandMore />}</Typ>
             </div>

--- a/src/components/EpisodeCard.tsx
+++ b/src/components/EpisodeCard.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { Episode } from '../types';
+import { CardMedia, Typography as Typ } from '@mui/material';
+import Divider from '@mui/material/Divider';
+import { ExpandLess, ExpandMore } from '@mui/icons-material/';
+import { formatReleaseDate, DateSize } from '../helpers';
+
+interface EpisodeCardProps {
+    details: Episode;
+}
+
+/**
+ * Component to render a TV Show Episode and its details
+ */
+const EpisodeCard: React.FC<EpisodeCardProps> = ({ details }): JSX.Element => {
+    const [expand, setExpand] = useState<boolean>(false);
+    return (
+        <div className='my-3 bg-foreground rounded-b-md w-full rounded-sm max-w-[275px] md:max-w-none'>
+            <div data-testid='episode-card-component' className='flex flex-col md:flex-row '>
+                <CardMedia
+                    component='img'
+                    className='rounded-t-sm'
+                    sx={{
+                        boxShadow: 5,
+                        width: 275,
+                        maxHeight: 270,
+                        '&:hover': { cursor: 'pointer' },
+                    }}
+                    image={
+                        details.still_path
+                            ? `https://image.tmdb.org/t/p/w500${details.still_path}`
+                            : '/poster-placeholder.jpeg'
+                    }
+                    alt={details.name + ' poster'}
+                />
+                <div className='px-3 flex flex-col truncate'>
+                    <div className='py-2 w-full flex justify-between items-center md:justify-start truncate md:space-x-2'>
+                        <Typ>{details.episode_number}.</Typ>
+                        <Typ fontWeight={'bold'} className='grow md:grow-0 truncate'>
+                            {details.name}
+                        </Typ>
+                    </div>
+                    <div className='hidden md:flex space-x-3'>
+                        <Typ variant='subtitle1'>{details.vote_average}</Typ>
+                        <Typ variant='subtitle1'>
+                            {formatReleaseDate(details.air_date, DateSize.MEDIUM)}
+                        </Typ>
+                        <Typ variant='subtitle1'>{details.runtime}m</Typ>
+                    </div>
+                    <div className='py-2 hidden md:block'>
+                        <Typ
+                            variant='body2'
+                            className='text-wrap text-left'
+                            sx={{
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                display: '-webkit-box',
+                                WebkitLineClamp: '3',
+                                WebkitBoxOrient: 'vertical',
+                            }}
+                        >
+                            {details.overview}
+                        </Typ>
+                    </div>
+                </div>
+                <div
+                    className='md:hidden'
+                    style={{
+                        maxHeight: expand ? '600px' : '0px',
+                        overflow: 'hidden',
+                        transition: 'max-height .5s ease-in-out',
+                    }}
+                >
+                    <Divider />
+                    <div className='p-4'>
+                        <div className='flex flex-row justify-start space-x-3'>
+                            <Typ variant='subtitle1'>{details.vote_average}</Typ>
+                            <Typ variant='subtitle1'>
+                                {formatReleaseDate(details.air_date, DateSize.MEDIUM)}
+                            </Typ>
+                            <Typ variant='subtitle1'>{details.runtime}m</Typ>
+                        </div>
+                        <Typ
+                            sx={{
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                display: '-webkit-box',
+                                WebkitLineClamp: '15',
+                                WebkitBoxOrient: 'vertical',
+                            }}
+                            variant='body2'
+                            className='text-left pt-4'
+                        >
+                            {details.overview}
+                        </Typ>
+                        <div className='text-left pt-4'>
+                            {/* possible undefined values WIP */}
+                            <Typ variant='body2'>
+                                Directed by:{' '}
+                                {details.crew.find((item) => item.job == 'Director')?.name}
+                            </Typ>
+                            <Typ variant='body2'>
+                                Written by:{' '}
+                                {
+                                    details.crew.find(
+                                        (item) => item.job == 'Writer' || item.job == 'Story'
+                                    )?.name
+                                }
+                            </Typ>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <Divider />
+            <div
+                onClick={() => setExpand(!expand)}
+                className='py-1 px-2 cursor-pointer hover:opacity-70'
+            >
+                <Typ variant='subtitle2'>Expand{expand ? <ExpandLess /> : <ExpandMore />}</Typ>
+            </div>
+        </div>
+    );
+};
+
+export default EpisodeCard;

--- a/src/components/EpisodeCard.tsx
+++ b/src/components/EpisodeCard.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
-import { Episode } from '../types';
+import { useState, useEffect } from 'react';
+import { Episode, EpisodeDetails } from '../types';
 import { CardMedia, Typography as Typ } from '@mui/material';
 import Divider from '@mui/material/Divider';
 import { ExpandLess, ExpandMore } from '@mui/icons-material/';
 import { formatReleaseDate, DateSize } from '../helpers';
+import { getTvEpisodeDetails } from '../helpers';
 
 interface EpisodeCardProps {
     details: Episode;
@@ -14,6 +15,21 @@ interface EpisodeCardProps {
  */
 const EpisodeCard: React.FC<EpisodeCardProps> = ({ details }): JSX.Element => {
     const [expand, setExpand] = useState<boolean>(false);
+    const [episodeDetails, setEpisodeDetails] = useState<EpisodeDetails | null>(null);
+    // console.log(details);
+
+    useEffect(() => {
+        const handler = async () => {
+            const episodeDetails = await getTvEpisodeDetails(
+                details.show_id,
+                details.season_number,
+                details.episode_number
+            );
+            setEpisodeDetails(episodeDetails);
+        };
+        if (expand) handler();
+    }, [expand]);
+
     return (
         <div className='my-3 bg-foreground rounded-b-md w-full rounded-sm max-w-[275px] md:max-w-none'>
             <div data-testid='episode-card-component' className='flex flex-col md:flex-row '>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,6 +20,7 @@ import OfflineSnackbar from './OfflineSnackbar';
 import Footer from './Footer';
 import TextInput from './TextInput';
 import Banner from './Banner';
+import EpisodeCard from './EpisodeCard';
 
 export {
     ActorCard,
@@ -40,6 +41,7 @@ export {
     Footer,
     TextInput,
     Banner,
+    EpisodeCard,
 };
 export * from './loaders';
 export * from './modals';

--- a/src/helpers/getTvUtils.ts
+++ b/src/helpers/getTvUtils.ts
@@ -7,6 +7,7 @@ import {
     DiscoverTv,
     TvData,
     SeasonDetails,
+    EpisodeDetails,
 } from '../types';
 import { convertDetailsToShowType, convertResultsToShowType } from './showTypeUtils';
 
@@ -176,6 +177,28 @@ const getTvSeasonDetails = async (showId: number, season_num: number): Promise<S
     return data;
 };
 
+/**
+ * Provides additional Episode details that are not provided by Season Details
+ * @param showId
+ * @param season_num
+ * @param episode_num
+ * @returns {Promise<EpisodeDetails>}
+ */
+const getTvEpisodeDetails = async (
+    showId: number,
+    season_num: number,
+    episode_num: number
+): Promise<EpisodeDetails> => {
+    const response = await fetch(
+        `https://api.themoviedb.org/3/tv/${showId}/season/${season_num}/episode/${episode_num}?api_key=${import.meta.env.VITE_MOVIEDB_KEY}&append_to_response=images,videos,credits`
+    );
+    if (!response.ok) {
+        LOG.error('Fetch request failed with a status of ' + response.status);
+    }
+    const data: EpisodeDetails = await response.json();
+    return data;
+};
+
 export {
     getTvByName,
     getTvDetails,
@@ -185,4 +208,5 @@ export {
     getDiscoverTv,
     getTvRating,
     getTvSeasonDetails,
+    getTvEpisodeDetails,
 };

--- a/src/helpers/getTvUtils.ts
+++ b/src/helpers/getTvUtils.ts
@@ -1,5 +1,13 @@
 import Logger from '../logger';
-import { ShowData, TvDetailsData, TvResults, ShowProviders, DiscoverTv, TvData } from '../types';
+import {
+    ShowData,
+    TvDetailsData,
+    TvResults,
+    ShowProviders,
+    DiscoverTv,
+    TvData,
+    SeasonDetails,
+} from '../types';
 import { convertDetailsToShowType, convertResultsToShowType } from './showTypeUtils';
 
 const LOG = new Logger('getTvUtils');
@@ -151,6 +159,23 @@ const getTvRating = (arr: TvDetailsData) => {
     return 'No rating available';
 };
 
+/**
+ * Provides more details of an individual season
+ * @param showId
+ * @param season_num
+ * @returns {Promise<SeasonDetails>}
+ */
+const getTvSeasonDetails = async (showId: number, season_num: number): Promise<SeasonDetails> => {
+    const response = await fetch(
+        `https://api.themoviedb.org/3/tv/${showId}/season/${season_num}?api_key=${import.meta.env.VITE_MOVIEDB_KEY}`
+    );
+    if (!response.ok) {
+        LOG.error('Fetch request failed with a status of ' + response.status);
+    }
+    const data: SeasonDetails = await response.json();
+    return data;
+};
+
 export {
     getTvByName,
     getTvDetails,
@@ -159,4 +184,5 @@ export {
     getTvRecommendations,
     getDiscoverTv,
     getTvRating,
+    getTvSeasonDetails,
 };

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -14,6 +14,7 @@ import {
     DashboardLayout,
     ActorDetailScreen,
     SeasonsScreen,
+    SeasonDetailsScreen,
 } from './screens';
 import { loader as searchLoader } from './screens/search_results/SearchResultsScreen';
 import { loader as dashGalleryLoader } from './screens/dashboard/DashboardGalleryScreen';
@@ -94,6 +95,10 @@ export const routes: RouteObject[] = [
                     {
                         path: 'tv/:id/seasons',
                         element: <SeasonsScreen />,
+                    },
+                    {
+                        path: 'tv/:id/seasons/:num',
+                        element: <SeasonDetailsScreen />,
                     },
                     {
                         path: 'actor/:id',

--- a/src/screens/SeasonDetailsScreen.tsx
+++ b/src/screens/SeasonDetailsScreen.tsx
@@ -1,0 +1,64 @@
+import { useState, useEffect } from 'react';
+import { getTvSeasonDetails } from '../helpers';
+import { SeasonDetails } from '../types';
+import { Location, useLocation, Link } from 'react-router';
+import { CardMedia, Typography as Typ } from '@mui/material';
+
+/**
+ * Screen to render a TV Show's Season's Episodes
+ */
+const SeasonDetailsScreen: React.FC = (): JSX.Element => {
+    const location: Location = useLocation();
+    const showId = parseInt(location.pathname.split('/')[3]);
+    const seasonNum = parseInt(location.pathname.split('/')[5]);
+    const [details, setDetails] = useState<SeasonDetails | null>(null);
+
+    useEffect(() => {
+        const handler = async () => {
+            const seasonDetails = await getTvSeasonDetails(showId, seasonNum);
+            setDetails(seasonDetails);
+        };
+        handler();
+    }, [location]);
+
+    return (
+        <section
+            data-testid='season-details-screen'
+            className='m-6 flex items-center sm:items-start flex-col w-[70svw] max-w-[1380px]'
+        >
+            <div className='mb-3 flex flex-col sm:flex-row items-center'>
+                <CardMedia
+                    component='img'
+                    className='rounded-sm'
+                    sx={{
+                        boxShadow: 5,
+                        width: 58,
+                        height: 87,
+                    }}
+                    image={
+                        details?.poster_path
+                            ? `https://image.tmdb.org/t/p/w500${details.poster_path}`
+                            : '/poster-placeholder.jpeg'
+                    }
+                    alt={details?.name + ' poster'}
+                />
+                <div className='flex flex-col sm:items-start'>
+                    <div className='flex flex-col sm:flex-row items-center'>
+                        <Typ className='sm:pl-2' fontWeight={'bold'} variant='h4'>
+                            {details?.name}
+                        </Typ>
+                        <Typ className='sm:pl-2'>{'(' + details?.air_date?.slice(0, 4) + ')'}</Typ>
+                    </div>
+                    <Link
+                        className='sm:pl-2 hover:text-blue-500 cursor-pointer'
+                        to={`/details/tv/${showId}/seasons`}
+                    >
+                        Back to Seasons
+                    </Link>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default SeasonDetailsScreen;

--- a/src/screens/SeasonDetailsScreen.tsx
+++ b/src/screens/SeasonDetailsScreen.tsx
@@ -4,6 +4,7 @@ import { SeasonDetails } from '../types';
 import { Location, useLocation, Link } from 'react-router';
 import { CardMedia, Typography as Typ } from '@mui/material';
 import { EpisodeCard } from '../components';
+import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
 
 /**
  * Screen to render a TV Show's Season's Episodes
@@ -56,6 +57,7 @@ const SeasonDetailsScreen: React.FC = (): JSX.Element => {
                         className='sm:pl-2 hover:text-blue-500 cursor-pointer'
                         to={`/details/tv/${showId}/seasons`}
                     >
+                        <ArrowBackRoundedIcon />
                         Back to Seasons
                     </Link>
                 </div>

--- a/src/screens/SeasonDetailsScreen.tsx
+++ b/src/screens/SeasonDetailsScreen.tsx
@@ -3,6 +3,7 @@ import { getTvSeasonDetails } from '../helpers';
 import { SeasonDetails } from '../types';
 import { Location, useLocation, Link } from 'react-router';
 import { CardMedia, Typography as Typ } from '@mui/material';
+import { EpisodeCard } from '../components';
 
 /**
  * Screen to render a TV Show's Season's Episodes
@@ -24,7 +25,7 @@ const SeasonDetailsScreen: React.FC = (): JSX.Element => {
     return (
         <section
             data-testid='season-details-screen'
-            className='m-6 flex items-center sm:items-start flex-col w-[70svw] max-w-[1380px]'
+            className='m-6 flex items-center md:items-start flex-col w-[70svw] max-w-[1380px]'
         >
             <div className='mb-3 flex flex-col sm:flex-row items-center'>
                 <CardMedia
@@ -47,7 +48,9 @@ const SeasonDetailsScreen: React.FC = (): JSX.Element => {
                         <Typ className='sm:pl-2' fontWeight={'bold'} variant='h4'>
                             {details?.name}
                         </Typ>
-                        <Typ className='sm:pl-2'>{'(' + details?.air_date?.slice(0, 4) + ')'}</Typ>
+                        <Typ className='sm:pl-2'>
+                            {details?.air_date ? '(' + details?.air_date?.slice(0, 4) + ')' : '-'}
+                        </Typ>
                     </div>
                     <Link
                         className='sm:pl-2 hover:text-blue-500 cursor-pointer'
@@ -57,6 +60,8 @@ const SeasonDetailsScreen: React.FC = (): JSX.Element => {
                     </Link>
                 </div>
             </div>
+
+            {details?.episodes.map((item, i) => <EpisodeCard details={item} key={i} />)}
         </section>
     );
 };

--- a/src/screens/SeasonsScreen.tsx
+++ b/src/screens/SeasonsScreen.tsx
@@ -43,7 +43,6 @@ const SeasonsScreen: React.FC = (): JSX.Element => {
                         boxShadow: 5,
                         width: 58,
                         height: 87,
-                        '&:hover': { opacity: 0.8 },
                     }}
                     image={
                         details.poster_path

--- a/src/screens/SeasonsScreen.tsx
+++ b/src/screens/SeasonsScreen.tsx
@@ -5,6 +5,7 @@ import { getTvDetails } from '../helpers';
 import { SeasonCard, SeasonCardLoader } from '../components';
 import { default as Typ } from '@mui/material/Typography';
 import { CardMedia } from '@mui/material';
+import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded';
 
 /**
  * Screen to render all of a TV Show's Seasons
@@ -65,6 +66,7 @@ const SeasonsScreen: React.FC = (): JSX.Element => {
                         to={`/details/tv/${details.id}`}
                         state={{ details: details }}
                     >
+                        <ArrowBackRoundedIcon />
                         Back to Show Details
                     </Link>
                 </div>

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -9,6 +9,7 @@ import PageNotFoundScreen from './PageNotFoundScreen';
 import ShowDetailsScreen from './ShowDetailsScreen';
 import ActorDetailScreen from './ActorDetailScreen';
 import SeasonsScreen from './SeasonsScreen';
+import SeasonDetailsScreen from './SeasonDetailsScreen';
 
 export * from './auth';
 export * from './dashboard';
@@ -22,4 +23,5 @@ export {
     ShowDetailsScreen,
     DiscoverDetailScreen,
     SeasonsScreen,
+    SeasonDetailsScreen,
 };

--- a/src/stories/components/EpisodeCard.stories.ts
+++ b/src/stories/components/EpisodeCard.stories.ts
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { EpisodeCard } from '../../components';
+import { EPISODE } from '../constants';
+import { withRouter, reactRouterParameters } from 'storybook-addon-remix-react-router';
+
+const meta = {
+    title: 'Components/Episode Card',
+    component: EpisodeCard,
+    tags: ['autodocs'],
+    parameters: {
+        reactRouter: reactRouterParameters({
+            location: {
+                path: '/details/tv/:show_id/seasons/:season_num',
+                pathParams: { show_id: EPISODE.show_id, season_num: EPISODE.season_number },
+            },
+            routing: {
+                path: '/details/tv/:show_id/seasons/:season_num',
+                handle: 'details',
+            },
+        }),
+    },
+    decorators: [withRouter],
+} satisfies Meta<typeof EpisodeCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Episode: Story = {
+    args: {
+        details: EPISODE,
+    },
+};

--- a/src/stories/constants.ts
+++ b/src/stories/constants.ts
@@ -1,5 +1,5 @@
 /* eslint-disable prettier/prettier */
-import { Profile, Session, ShowData } from '../types';
+import { Profile, Session, ShowData, Episode } from '../types';
 
 export const PROFILE: Profile = {
     id: '1234',
@@ -325,4 +325,101 @@ export const SEASON = {
     poster_path: '/wgfKiqzuMrFIkU1M68DDDY8kGC1.jpg',
     season_number: 1,
     vote_average: 8.3,
+};
+
+export const EPISODE: Episode = {
+    air_date: '2011-04-17',
+    episode_number: 1,
+    id: 63056,
+    name: 'Winter Is Coming',
+    overview: 'Jon Arryn, the Hand of the King, is dead. King Robert Baratheon plans to ask his oldest friend, Eddard Stark, to take Jon\'s place. Across the sea, Viserys Targaryen plans to wed his sister to a nomadic warlord in exchange for an army.',
+    production_code: '101',
+    runtime: 62,
+    season_number: 1,
+    show_id: 1399,
+    still_path: '/9hGF3WUkBf7cSjMg0cdMDHJkByd.jpg',
+    vote_average: 8.033,
+    vote_count: 361,
+    crew: [
+        {
+            job: 'Writer',
+            department: 'Writing',
+            credit_id: '5256c8a019c2956ff6046e2b',
+            adult: false,
+            gender: 2,
+            id: 9813,
+            known_for_department: 'Writing',
+            name: 'David Benioff',
+            original_name: 'David Benioff',
+            popularity: 0.184,
+            profile_path: '/bOlW8pymCeQLfwPIvc2D1MRcUoF.jpg'
+        },
+        {
+            department: 'Directing',
+            job: 'Director',
+            credit_id: '5256c8a219c2956ff6046e77',
+            adult: false,
+            gender: 2,
+            id: 44797,
+            known_for_department: 'Directing',
+            name: 'Tim Van Patten',
+            original_name: 'Tim Van Patten',
+            popularity: 0.161,
+            profile_path: '/vwcARZBg4PEzOwnPsXdjRWeUVrZ.jpg'
+        },
+        {
+            job: 'Writer',
+            department: 'Writing',
+            credit_id: '5256c8a219c2956ff6046e4b',
+            adult: false,
+            gender: 2,
+            id: 228068,
+            known_for_department: 'Writing',
+            name: 'D. B. Weiss',
+            original_name: 'D. B. Weiss',
+            popularity: 0.119,
+            profile_path: '/2RMejaT793U9KRk2IEbFfteQntE.jpg'
+        }
+    ],
+    guest_stars: [
+        {
+            character: 'Benjen Stark',
+            credit_id: '5256c8b919c2956ff604836a',
+            order: 61,
+            adult: false,
+            gender: 2,
+            id: 119783,
+            known_for_department: 'Acting',
+            name: 'Joseph Mawle',
+            original_name: 'Joseph Mawle',
+            popularity: 0.281,
+            profile_path: '/1Ocb9v3h54beGVoJMm4w50UQhLf.jpg'
+        },
+        {
+            character: 'Rickon Stark',
+            credit_id: '566a83bcc3a3683f56003604',
+            order: 80,
+            adult: false,
+            gender: 2,
+            id: 1050248,
+            known_for_department: 'Acting',
+            name: 'Art Parkinson',
+            original_name: 'Art Parkinson',
+            popularity: 0.113,
+            profile_path: '/ejAKOJME1DsvHECLWdQ7dEtXyyc.jpg'
+        },
+        {
+            character: 'Hodor',
+            credit_id: '5256c8be19c2956ff6048446',
+            order: 81,
+            adult: false,
+            gender: 2,
+            id: 1223792,
+            known_for_department: 'Acting',
+            name: 'Kristian Nairn',
+            original_name: 'Kristian Nairn',
+            popularity: 0.077,
+            profile_path: '/dlbq6cCW0xdpFY15q6flP6lDXWV.jpg'
+        }
+    ]
 };

--- a/src/types/tmdb/actor.ts
+++ b/src/types/tmdb/actor.ts
@@ -13,10 +13,24 @@ export interface Actor {
     original_name: string;
     popularity: number;
     profile_path: string;
-    cast_id: number;
+    cast_id?: number;
     character: string;
     credit_id: string;
     order: number;
+}
+
+export interface Crew {
+    adult: boolean;
+    gender: number;
+    id: number;
+    known_for_department: string;
+    name: string;
+    original_name: string;
+    popularity: number;
+    profile_path: string;
+    credit_id: string;
+    department: string;
+    job: string;
 }
 
 /**

--- a/src/types/tmdb/show.ts
+++ b/src/types/tmdb/show.ts
@@ -1,6 +1,6 @@
 import { Actor } from './actor';
 import { MovieData } from './movie';
-import { TvData } from './tv';
+import { TvData, Season } from './tv';
 
 /**
  * Object containing genre as string and TMDB genre id
@@ -89,17 +89,6 @@ export interface ShowProviders {
     };
 }
 
-export interface Season {
-    air_date: string | null;
-    episode_count: number;
-    id: number;
-    name: string;
-    overview: string;
-    poster_path: string | null;
-    season_number: number;
-    vote_average: number;
-}
-
 /**
  * Returned by getMovieDetails and getTvDetails
  * Custom type to work with both tv and movies
@@ -141,26 +130,4 @@ export interface ShowResults {
     results?: Array<MovieData | TvData>;
     total_pages: number;
     total_results: number;
-}
-
-export interface SeasonDetails extends Season {
-    _id: string;
-    episodes: [
-        {
-            air_date: string;
-            episode_number: number;
-            id: number;
-            name: string;
-            overview: string;
-            production_code: string;
-            runtime: number;
-            season_number: number;
-            show_id: number;
-            still_path: string;
-            vote_average: number;
-            vote_count: number;
-            crew: Actor[];
-            guest_stars: Actor[];
-        },
-    ];
 }

--- a/src/types/tmdb/show.ts
+++ b/src/types/tmdb/show.ts
@@ -142,3 +142,25 @@ export interface ShowResults {
     total_pages: number;
     total_results: number;
 }
+
+export interface SeasonDetails extends Season {
+    _id: string;
+    episodes: [
+        {
+            air_date: string;
+            episode_number: number;
+            id: number;
+            name: string;
+            overview: string;
+            production_code: string;
+            runtime: number;
+            season_number: number;
+            show_id: number;
+            still_path: string;
+            vote_average: number;
+            vote_count: number;
+            crew: Actor[];
+            guest_stars: Actor[];
+        },
+    ];
+}

--- a/src/types/tmdb/tv.ts
+++ b/src/types/tmdb/tv.ts
@@ -34,39 +34,6 @@ export interface TvResults {
     total_results?: number;
 }
 
-export interface Season {
-    air_date: string | null;
-    episode_count: number;
-    id: number;
-    name: string;
-    overview: string;
-    poster_path: string | null;
-    season_number: number;
-    vote_average: number;
-}
-
-export interface SeasonDetails extends Season {
-    _id: string;
-    episodes: Episode[];
-}
-
-export interface Episode {
-    air_date: string;
-    episode_number: number;
-    id: number;
-    name: string;
-    overview: string;
-    production_code: string;
-    runtime: number;
-    season_number: number;
-    show_id: number;
-    still_path: string;
-    vote_average: number;
-    vote_count: number;
-    crew: (Actor & { job: string })[];
-    guest_stars: Actor[];
-}
-
 export interface NextEpisodeData {
     air_date: string;
     episode_number: number;
@@ -197,4 +164,72 @@ export interface DiscoverTv {
     first_air_date_lte?: string;
     with_watch_providers?: string;
     watch_region?: string;
+}
+
+export interface Season {
+    air_date: string | null;
+    episode_count: number;
+    id: number;
+    name: string;
+    overview: string;
+    poster_path: string | null;
+    season_number: number;
+    vote_average: number;
+}
+
+export interface SeasonDetails extends Season {
+    _id: string;
+    episodes: Episode[];
+}
+
+export interface Episode {
+    air_date: string;
+    episode_number: number;
+    id: number;
+    name: string;
+    overview: string;
+    production_code: string;
+    runtime: number;
+    season_number: number;
+    show_id: number;
+    still_path: string;
+    vote_average: number;
+    vote_count: number;
+    crew: (Actor & { job: string })[];
+    guest_stars: Actor[];
+}
+
+export interface EpisodeDetails extends Episode {
+    credits: {
+        cast: Actor[];
+    };
+    images: {
+        stills: [
+            {
+                aspect_ratio: number;
+                height: number;
+                iso_639_1: string;
+                file_path: string;
+                vote_average: number;
+                vote_count: number;
+                width: number;
+            },
+        ];
+    };
+    videos: {
+        results: [
+            {
+                iso_639_1: string;
+                iso_3166_1: string;
+                name: string;
+                key: string;
+                site: string;
+                size: number;
+                type: string;
+                official: boolean;
+                published_at: string;
+                id: string;
+            },
+        ];
+    };
 }

--- a/src/types/tmdb/tv.ts
+++ b/src/types/tmdb/tv.ts
@@ -34,6 +34,39 @@ export interface TvResults {
     total_results?: number;
 }
 
+export interface Season {
+    air_date: string | null;
+    episode_count: number;
+    id: number;
+    name: string;
+    overview: string;
+    poster_path: string | null;
+    season_number: number;
+    vote_average: number;
+}
+
+export interface SeasonDetails extends Season {
+    _id: string;
+    episodes: Episode[];
+}
+
+export interface Episode {
+    air_date: string;
+    episode_number: number;
+    id: number;
+    name: string;
+    overview: string;
+    production_code: string;
+    runtime: number;
+    season_number: number;
+    show_id: number;
+    still_path: string;
+    vote_average: number;
+    vote_count: number;
+    crew: (Actor & { job: string })[];
+    guest_stars: Actor[];
+}
+
 export interface NextEpisodeData {
     air_date: string;
     episode_number: number;
@@ -108,18 +141,7 @@ export interface TvDetailsData extends TvData {
             name: string;
         },
     ];
-    seasons?: [
-        {
-            air_date: string;
-            episode_count: number;
-            id: number;
-            name: string;
-            overview: string;
-            poster_path: string;
-            season_number: number;
-            vote_average: number;
-        },
-    ];
+    seasons?: Season[];
     spoken_languages: [
         {
             english_name: string;

--- a/src/types/tmdb/tv.ts
+++ b/src/types/tmdb/tv.ts
@@ -1,4 +1,4 @@
-import { Actor } from './actor';
+import { Actor, Crew } from './actor';
 import { ShowGenre, ShowProviders } from './show';
 
 /**
@@ -195,41 +195,37 @@ export interface Episode {
     still_path: string;
     vote_average: number;
     vote_count: number;
-    crew: (Actor & { job: string })[];
+    crew: Crew[];
     guest_stars: Actor[];
 }
 
-export interface EpisodeDetails extends Episode {
+export interface EpisodeDetails extends Partial<Episode> {
     credits: {
         cast: Actor[];
     };
     images: {
-        stills: [
-            {
-                aspect_ratio: number;
-                height: number;
-                iso_639_1: string;
-                file_path: string;
-                vote_average: number;
-                vote_count: number;
-                width: number;
-            },
-        ];
+        stills: {
+            aspect_ratio: number;
+            height: number;
+            iso_639_1: string;
+            file_path: string;
+            vote_average: number;
+            vote_count: number;
+            width: number;
+        }[];
     };
     videos: {
-        results: [
-            {
-                iso_639_1: string;
-                iso_3166_1: string;
-                name: string;
-                key: string;
-                site: string;
-                size: number;
-                type: string;
-                official: boolean;
-                published_at: string;
-                id: string;
-            },
-        ];
+        results: {
+            iso_639_1: string;
+            iso_3166_1: string;
+            name: string;
+            site: string;
+            key: string;
+            size: number;
+            type: string;
+            official: boolean;
+            published_at: string;
+            id: string;
+        }[];
     };
 }


### PR DESCRIPTION
# Description

This PR is the final merge to complete #673 

## New Features

- `SeasonDetailsScreen` to render an individual TV Show Season and its episodes. Closes #1136 
    - `SeasonDetailsScreen` UI Tests.
    
    - `getTvSeasonDetails` [TMDB Request](https://developer.themoviedb.org/reference/tv-season-details). Closes #1137 
    
    - `SeasonDetails` interface.

- `EpisodeCard` to render individual episods for a given season. Closes #1135 
    - `EpisodeCard` UI Tests.
    
    - `EpisodeCard` Storybook.
    
    -  `getTvEpisodeDetails` [TMDB Request](https://developer.themoviedb.org/reference/tv-episode-details). This request provides per episode cast and images not provided by the `getTvSeasonDetails` request. Additionally, the `append_to_response` parameter `videos` is included, enabling future development opportunities to implement trailers, clips, and more.
    
    - `EpisodeDetails` interface.

## Screenshots

### Mobile

![image](https://github.com/user-attachments/assets/006647ff-db28-46df-9c6f-1ad851c2995d)

### Mobile Expanded

![image](https://github.com/user-attachments/assets/2a16f848-ad41-4827-a019-05743240b572)

### Tablet+

![image](https://github.com/user-attachments/assets/9c56a976-e11b-462d-ac92-1ca50d0b8fb5)

### Tablet+ Expanded

![image](https://github.com/user-attachments/assets/5014489a-4fa1-459b-beb6-498b7f08f4bd)

## Modifications

- Removed ESLint rules for `indent` and `quotes`. No longer supported as of [v8.53.0](https://github.com/eslint/eslint/releases/tag/v8.53.0)
- Removed all instantiations of `TMDB_BASE_PATH` in test files. It is now defined in our constants file and imported as needed.
- Created a `Crew` interface for readability/simplicity. 

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created
