### PR TITLE
autofocus search input when expanding search on tablet view

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -241,7 +241,7 @@ const Navigation: React.FC<NavigationProps> = ({ session, theme, switchTheme }):
             {/* TODO: Add a transition when search is expanded or collapsed */}
             {expandedSearch && (
                 <div className='flex items-center justify-center bg-foreground px-8 py-3'>
-                    <SearchInput />
+                    <SearchInput autoFocus />
                 </div>
             )}
         </AppBar>

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -10,13 +10,17 @@ interface SearchInputProps {
      * Override the default text color of the input
      */
     colorOverride?: 'white' | 'black';
+    /**
+     * If the input should automatically focus on render
+     */
+    autoFocus?: boolean;
 }
 
 /**
  * Currently using a react router form, this will redirect to /search?q=INPUT
  * We can then pull the query from the URL and don't need to pass it as props
  */
-const SearchInput: React.FC<SearchInputProps> = ({ colorOverride }) => {
+const SearchInput: React.FC<SearchInputProps> = ({ colorOverride, autoFocus }) => {
     const [searchTerm, setSearchTerm] = useState('');
     const url = new URL(window.location.href);
     const query = url.searchParams.get('q')?.trim();
@@ -49,6 +53,7 @@ const SearchInput: React.FC<SearchInputProps> = ({ colorOverride }) => {
                 variant='filled'
                 ariaLabel='search'
                 required
+                autoFocus={autoFocus}
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 endAdornment={

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -60,6 +60,10 @@ interface TextInputProps {
      */
     onFocus?: () => void;
     /**
+     * If the input should automatically focus when rendered
+     */
+    autoFocus?: boolean;
+    /**
      * Icon to show in the input field
      */
     endAdornment?: ReactElement;
@@ -91,6 +95,7 @@ const TextInput: React.FC<TextInputProps> = ({
     required,
     onChange,
     onFocus,
+    autoFocus,
     endAdornment,
     ariaLabel,
     inputProps,
@@ -111,6 +116,7 @@ const TextInput: React.FC<TextInputProps> = ({
                 required={required}
                 onChange={onChange}
                 onFocus={onFocus}
+                autoFocus={autoFocus}
                 endAdornment={endAdornment}
                 aria-label={ariaLabel}
                 inputProps={{ ...inputProps }}


### PR DESCRIPTION
# Description

<!-- Provide a description of the changes made -->
Focus search input after expanding search on tablet/mobile view. Still does not autofocus in other scenarios. 

Closes #1186 

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created
