### PR TITLE
remove people from show search results

### DIFF
--- a/src/hooks/usePaginatedData.ts
+++ b/src/hooks/usePaginatedData.ts
@@ -46,7 +46,11 @@ const usePaginatedData = ({ query }: PaginatedDataProps) => {
                 return;
             }
 
-            const nextPage: ShowData[] = json.results.map((show) => {
+            const filteredData = json.results.filter(
+                (result) => (result.media_type as string) !== 'person'
+            );
+
+            const nextPage: ShowData[] = filteredData.map((show) => {
                 return {
                     id: show.id,
                     poster_path: show.poster_path,


### PR DESCRIPTION
# Description

Not sure exactly when this started happening, but actors are now included in our search results data. As far as I remember, this did not used to be the case. For the quick fix here, I have simply removed actors from the search result data.

- #1187 
- #1188 
- #1189
> These tickets will make it so actors can be properly search for, but this will be a larger effort. 

Closes #1234 

## Screenshot

![image](https://github.com/user-attachments/assets/3ebd83f8-0844-4a52-afce-e5fdf50d9ced)

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created
