### PR TITLE
Fix queue button flicker

### DIFF
--- a/src/hooks/useIsInProfileArray.ts
+++ b/src/hooks/useIsInProfileArray.ts
@@ -16,9 +16,21 @@ const useIsInProfileArray = (
     isInFavorites: boolean;
     isInWatched: boolean;
 } => {
-    const [isInQueue, setIsInQueue] = useState(false);
-    const [isInFavorites, setIsInFavorites] = useState(false);
-    const [isInWatched, setIsInWatched] = useState(false);
+    const [isInQueue, setIsInQueue] = useState(
+        profile?.queue?.includes('movie-' + showId.toString()) ||
+            profile?.queue?.includes('tv-' + showId.toString()) ||
+            false
+    );
+    const [isInFavorites, setIsInFavorites] = useState(
+        profile?.queue?.includes('movie-' + showId.toString()) ||
+            profile?.queue?.includes('tv-' + showId.toString()) ||
+            false
+    );
+    const [isInWatched, setIsInWatched] = useState(
+        profile?.queue?.includes('movie-' + showId.toString()) ||
+            profile?.queue?.includes('tv-' + showId.toString()) ||
+            false
+    );
 
     useEffect(() => {
         const isInQueue =


### PR DESCRIPTION
# Description

My initial fix is to set the default value to what is currently in the profile array. This seems to work to fix the flicker on the UI. 

> [!NOTE]
>  We might want to spend a bit more time thinking about this, as I still think every card re-renders when one is added to the queue. It feels totally fine to me, but probably a performance issue just waiting to bite us in the 🍑 .

Closes #1233

## Demo

https://github.com/user-attachments/assets/d3788488-858e-48f8-8753-bb60bf8f1173

## Checklist

<!-- Check off [x] once complete or if not applicable -->

- [x] Screenshots added for any UX changes
- [x] Demos attached for animations/interactions
- [x] Pointed at proper branch (`develop` not `main`)
- [x] Assigned PR to yourself
- [x] Requested review from code owners
- [x] Relevant labels added (`feature`, `documentation`, etc.)
- [x] `Closes #<issue-number>` added if this resolves a GitHub issue
- [x] Branch is up to date with develop, ran `git rebase develop` if necessary
- [x] All GitHub Actions are passing
- [x] `npm run todo-ci` ran if any todo comments were created
